### PR TITLE
Change 'Mod' -> 'Mode' in english launch options

### DIFF
--- a/assets/jsons/translations/en.json
+++ b/assets/jsons/translations/en.json
@@ -23,11 +23,11 @@
         },
         "version-viewer": {
             "launch-mods": {
-                "oculus": "Oculus Mod",
+                "oculus": "Oculus Mode",
                 "oculus-description": "If you are running Beat Saber through Steam, this allows you to play the game on an Oculus headset.",
-                "desktop": "Desktop Mod",
+                "desktop": "Desktop Mode",
                 "desktop-description": "This allows you to use WASD and the mouse to navigate around the menu in game. This makes testing much easier, because you don't have to put on your headset!",
-                "debug": "Debug Mod",
+                "debug": "Debug Mode",
                 "debug-description": "Enables the output log window for IPA. This will show the debug console that mods use."
             },
             "maps": {


### PR DESCRIPTION
On the "Launch" page, there are currently three launch options:
- `Oculus Mod`
- `Desktop Mod`
- `Debug Mod`

In my opinion, these should be translated to "Mode" instead, at least in English. "Mod" implies that it's a separate third party modification, such as installing another DLL

All of these options come natively with the software (`-vrmode oculus` and `fpfc` come with the game, and `--verbose` comes with BSIPA)