### PR TITLE
Move @types/color to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.3.0",
     "@types/archiver": "^5.3.1",
+    "@types/color": "^3.0.3",
     "@types/dateformat": "^5.0.0",
     "@types/jest": "^27.5.2",
     "@types/node": "17.0.23",
@@ -230,7 +231,6 @@
   "dependencies": {
     "@node-steam/vdf": "^2.2.0",
     "@tippyjs/react": "^4.2.6",
-    "@types/color": "^3.0.3",
     "archiver": "^5.3.1",
     "color": "^4.2.3",
     "dateformat": "^5.0.3",


### PR DESCRIPTION
<!--

Please use the content below as a template for your pull request.
Feel free to remove sections which do not make sense.

-->

## Scope

When running `npm install`, it was failing to find the `@types/color` dependency.
Moving this dependency to `devDependencies` with the others fixed the issue.

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

| | | |
| --- | --- | --- |
| Blocking | 🔴 ❌ 🚨 | RED |
| Non-blocking | 🟡 💡 🤔 💭 | Yellow, thinking, etc |
| Praise | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
