### PR TITLE
Properly kill the download process on non-Windows systems

### DIFF
--- a/src/main/services/bs-installer.service.ts
+++ b/src/main/services/bs-installer.service.ts
@@ -67,8 +67,11 @@ export class BSInstallerService{
          if(this.downloadProcess?.killed && !this.downloadProcess?.pid){ return resolve(false); }
 
          this.downloadProcess.once('exit', () => resolve(true));
-
-         ctrlc(this.downloadProcess.pid);
+         if (process.platform === 'win32') {
+            ctrlc(this.downloadProcess.pid);
+         } else {
+            this.downloadProcess.kill();
+         }
          setTimeout(() => resolve(false), 3000);
       });
    }


### PR DESCRIPTION
## Scope

<!-- Brief description of WHAT you’re doing and WHY. -->
Currently, the `ctrlc-windows` package kills the download process when canceled.
This doesn't work on non-Windows systems, which this PR aims to fix.

## Implementation

This PR fixes the issue by only using the `ctrlc` package on Windows and using the normal `#kill` method on other operating systems, which send the appropriate `SIGTERM` signal to gracefully shutdown the process. 

## How to Test

The easiest way to test the change would be to start downloading a new version and cancel it part way through.

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

| | | |
| --- | --- | --- |
| Blocking | 🔴 ❌ 🚨 | RED |
| Non-blocking | 🟡 💡 🤔 💭 | Yellow, thinking, etc |
| Praise | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
