### PR TITLE
Use the platform native file manager when opening instance folder

### DIFF
--- a/src/main/ipcs/bs-version-ipcs.ts
+++ b/src/main/ipcs/bs-version-ipcs.ts
@@ -38,7 +38,6 @@ ipcMain.on('bs-version.installed-versions', async (event, req: IpcRequest<void>)
 ipcMain.on("bs-version.open-folder", async (event, req: IpcRequest<BSVersion>) => {
    const localVersionService = BSLocalVersionService.getInstance();
    const versionFolder = await localVersionService.getVersionPath(req.args);
-   (await pathExist(versionFolder)) && exec(`start "" "${versionFolder}"`);
    if (!(await pathExist(versionFolder)))
      return;
    shell.openPath(versionFolder);

--- a/src/main/ipcs/bs-version-ipcs.ts
+++ b/src/main/ipcs/bs-version-ipcs.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from 'electron';
+import { ipcMain, shell } from 'electron';
 import { UtilsService } from '../services/utils.service';
 import { BSVersionLibService } from '../services/bs-version-lib.service'
 import { BSVersion } from 'shared/bs-version.interface';
@@ -39,6 +39,9 @@ ipcMain.on("bs-version.open-folder", async (event, req: IpcRequest<BSVersion>) =
    const localVersionService = BSLocalVersionService.getInstance();
    const versionFolder = await localVersionService.getVersionPath(req.args);
    (await pathExist(versionFolder)) && exec(`start "" "${versionFolder}"`);
+   if (!(await pathExist(versionFolder)))
+     return;
+   shell.openPath(versionFolder);
 });
 
 ipcMain.on("bs-version.edit", async (event, req: IpcRequest<{version: BSVersion, name: string, color: string}>) => {


### PR DESCRIPTION
## Scope

<!-- Brief description of WHAT you’re doing and WHY. -->
Currently, when attempting to open the folder an instance is installed in, it runs a Windows command to open file explorer. This PR changes the behavior to work on all platforms.

## Implementation

Instead of executing a Windows command, Electron's `shell#openPath` method is used.

## How to Test

- Open the install folder of an instance.

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

| | | |
| --- | --- | --- |
| Blocking | 🔴 ❌ 🚨 | RED |
| Non-blocking | 🟡 💡 🤔 💭 | Yellow, thinking, etc |
| Praise | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
