### PR TITLE
Use the correct steam installation path on Linux

### DIFF
--- a/src/main/services/steam.service.ts
+++ b/src/main/services/steam.service.ts
@@ -1,11 +1,13 @@
 import { UtilsService } from "./utils.service";
 import regedit from 'regedit'
-import path from "path";
+import { path, join } from "path";
 import { parse } from "@node-steam/vdf";
 import { readFile } from "fs/promises";
 import { spawn } from "child_process";
 import { pathExist } from "../helpers/fs.helpers";
 import log from "electron-log";
+import psList from 'ps-list';
+import os from 'os';
 
 export class SteamService{
 
@@ -42,20 +44,28 @@ export class SteamService{
 
   public async getSteamPath(): Promise<string>{
 
-    if(!!this.steamPath){ return this.steamPath; }
+    if(this.steamPath){ return this.steamPath; }
 
-    const [win32Res, win64Res] = await Promise.all([
-      regedit.promisified.list(['HKLM\\SOFTWARE\\Valve\\Steam']),
-      regedit.promisified.list(['HKLM\\SOFTWARE\\WOW6432Node\\Valve\\Steam'])
-    ]);
+    switch (process.platform) {
+      case "linux":
+        this.steamPath = path.join(os.homedir(), '.steam', "steam");
+        return this.steamPath;
+      case "win32":
+        const [win32Res, win64Res] = await Promise.all([
+          regedit.promisified.list(['HKLM\\SOFTWARE\\Valve\\Steam']),
+          regedit.promisified.list(['HKLM\\SOFTWARE\\WOW6432Node\\Valve\\Steam'])
+        ]);
 
-    const [win32, win64] = [win32Res["HKLM\\SOFTWARE\\Valve\\Steam"], win64Res["HKLM\\SOFTWARE\\WOW6432Node\\Valve\\Steam"]];
-    
-    let res = '';
-    if(win64.exists && win64?.values?.InstallPath?.value){ res = win64.values.InstallPath.value as string; }
-    else if(win32.exists && win32?.values?.InstallPath?.value){ res = win32.values.InstallPath.value as string; }
-    this.steamPath = res;
-    return this.steamPath;
+        const [win32, win64] = [win32Res["HKLM\\SOFTWARE\\Valve\\Steam"], win64Res["HKLM\\SOFTWARE\\WOW6432Node\\Valve\\Steam"]];
+
+        let res = '';
+        if(win64.exists && win64?.values?.InstallPath?.value){ res = win64.values.InstallPath.value as string; }
+        else if(win32.exists && win32?.values?.InstallPath?.value){ res = win32.values.InstallPath.value as string; }
+        this.steamPath = res;
+        return res;
+      default:
+        return null;
+    }
   }
 
   public async getGameFolder(gameId: string, gameFolder?: string): Promise<string>{
@@ -86,7 +96,7 @@ export class SteamService{
         const process = spawn("start", ["steam://open/games"], {shell: true});
 
         process.on("error", log.error);
-    
+
         return new Promise(async (resolve, reject) => {
             // Every 3 seconds check if steam is running
             const interval = setInterval(async () => {

--- a/src/main/services/steam.service.ts
+++ b/src/main/services/steam.service.ts
@@ -6,8 +6,7 @@ import { readFile } from "fs/promises";
 import { spawn } from "child_process";
 import { pathExist } from "../helpers/fs.helpers";
 import log from "electron-log";
-import psList from 'ps-list';
-import os from 'os';
+import { app } from "electron";
 
 export class SteamService{
 
@@ -48,7 +47,7 @@ export class SteamService{
 
     switch (process.platform) {
       case "linux":
-        this.steamPath = path.join(os.homedir(), '.steam', "steam");
+        this.steamPath = path.join(app.getPath('home'), '.steam', "steam");
         return this.steamPath;
       case "win32":
         const [win32Res, win64Res] = await Promise.all([


### PR DESCRIPTION
## Scope

Currently, the steam installation path is retrieved from the Windows registry.
This PR allows the application to get the correct installation directory on Linux.

## Implementation

When getting the installation path, a switch statement defines the path, depending on the operating system. On Windows, the path is retrieved the same as before. On Linux, it's retrieved from `~/.steam/steam`, which, to my knowledge, Steam will always create.

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

| | | |
| --- | --- | --- |
| Blocking | 🔴 ❌ 🚨 | RED |
| Non-blocking | 🟡 💡 🤔 💭 | Yellow, thinking, etc |
| Praise | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
