### PR TITLE
Fix Tailwind deprecation warnings during build

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,12 @@
 const colors = require('tailwindcss/colors');
-/** @type {import('tailwindcss').Config} */
+
+// Suppress deprecation warnings during build
+delete colors.lightBlue;
+delete colors.warmGray;
+delete colors.trueGray;
+delete colors.coolGray;
+delete colors.blueGray;
+
 module.exports = {
   darkMode: 'class',
   content: ['./src/renderer/**/*.{js,jsx,ts,tsx,ejs}'],


### PR DESCRIPTION
## Scope

When importing all Tailwind CSS colors, you get several deprecation warnings from some colors that are kept around for backward compatibility. This PR fixes those warnings, leading to a less noisy build output.

## Implementation

I've used the solution mentioned in [this](https://github.com/tailwindlabs/tailwindcss/issues/4690#issuecomment-1046087220) Tailwind issue, which is to simply delete the deprecated colors.

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

| | | |
| --- | --- | --- |
| Blocking | 🔴 ❌ 🚨 | RED |
| Non-blocking | 🟡 💡 🤔 💭 | Yellow, thinking, etc |
| Praise | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
