### PR TITLE
fix(linux): search for info file case insensitively

### DIFF
--- a/src/main/helpers/fs.helpers.ts
+++ b/src/main/helpers/fs.helpers.ts
@@ -55,14 +55,11 @@ export async function getFoldersInFolder(folderPath: string, opts?: {ignoreSymli
 export async function getFilesInFolder(folderPath: string): Promise<string[]> {
     if(!(await pathExist(folderPath))){ return []; }
 
-    const files = await readdir(folderPath, {withFileTypes: true});
+    const dirEntries = await readdir(folderPath, {withFileTypes: true})
 
-    const promises = files.map(async file => {
-        if(file.isFile()){ return path.join(folderPath, file.name); }
-        return undefined;
-    });
-
-    return (await Promise.all(promises)).filter(file => file);
+    return dirEntries
+      .filter(entry => entry.isFile())
+      .map(file => path.join(folderPath, file.name));
 }
 
 export function moveFolderContent(src: string, dest: string): Observable<Progression>{

--- a/src/main/services/additional-content/local-maps-manager.service.ts
+++ b/src/main/services/additional-content/local-maps-manager.service.ts
@@ -96,12 +96,12 @@ export class LocalMapsManagerService {
 
     private async loadMapInfoFromPath(mapPath: string): Promise<BsmLocalMap>{
         const files = await getFilesInFolder(mapPath);
-        const infoFilePaths = files
-          .filter(file => (path.basename(file).toLowerCase() === "info.dat"))
+        const infoFile = files
+          .find(file => (path.basename(file).toLowerCase() === "info.dat"))
 
-        if(infoFilePaths.length === 0){ return null; }
+        if(infoFile === null){ return null; }
 
-        const rawInfoString = await readFile(infoFilePaths[0], {encoding: "utf-8"});
+        const rawInfoString = await readFile(infoFile, {encoding: "utf-8"});
 
         const rawInfo: RawMapInfoData = JSON.parse(rawInfoString);
         const coverUrl = new URL(`file:///${path.join(mapPath, rawInfo._coverImageFilename)}`).href;

--- a/src/main/services/additional-content/local-maps-manager.service.ts
+++ b/src/main/services/additional-content/local-maps-manager.service.ts
@@ -18,7 +18,7 @@ import { ipcMain } from "electron";
 import { IpcRequest } from 'shared/models/ipc';
 import { Observable, lastValueFrom } from "rxjs";
 import { Archive } from "../../models/archive.class";
-import { deleteFolder, ensureFolderExist, getFoldersInFolder, pathExist } from "../../helpers/fs.helpers";
+import { deleteFolder, ensureFolderExist, getFilesInFolder, getFoldersInFolder, pathExist } from "../../helpers/fs.helpers";
 import { readFile } from "fs/promises";
 import { FolderLinkerService } from "../folder-linker.service";
 import { allSettled } from "../../../shared/helpers/promise.helpers";
@@ -90,23 +90,25 @@ export class LocalMapsManagerService {
                 diffContent && shasum.update(diffContent);
             }
         }
-        
+
         return shasum.digest("hex");
     }
 
     private async loadMapInfoFromPath(mapPath: string): Promise<BsmLocalMap>{
-        const infoFilePath = path.join(mapPath, "Info.dat");
+        const files = await getFilesInFolder(mapPath);
+        const infoFilePaths = files
+          .filter(file => (path.basename(file).toLowerCase() === "info.dat"))
 
-        if(!(await pathExist(infoFilePath))){ return null; }
+        if(infoFilePaths.length === 0){ return null; }
 
-        const rawInfoString = await readFile(infoFilePath, {encoding: "utf-8"});
+        const rawInfoString = await readFile(infoFilePaths[0], {encoding: "utf-8"});
 
         const rawInfo: RawMapInfoData = JSON.parse(rawInfoString);
         const coverUrl = new URL(`file:///${path.join(mapPath, rawInfo._coverImageFilename)}`).href;
         const songUrl = new URL(`file:///${path.join(mapPath, rawInfo._songFilename)}`).href;
-        
+
         const hash = await this.computeMapHash(mapPath, rawInfoString);
-        
+
         return {rawInfo, coverUrl, songUrl, hash, path: mapPath};
     }
 
@@ -127,7 +129,7 @@ export class LocalMapsManagerService {
         ipcMain.once("one-click-map-info", async (event, req: IpcRequest<void>) => {
             this.utils.ipcSend(req.responceChannel, {success: true, data: {id: mapId, isHash}});
         });
-        
+
         this.windows.openWindow("oneclick-download-map.html");
 
     }
@@ -189,7 +191,7 @@ export class LocalMapsManagerService {
     }
 
     public deleteMaps(maps: BsmLocalMap[]): Observable<DeleteMapsProgress>{
-       
+
         const mapsFolders = maps.map(map => map.path);
         const mapsHashsToDelete = maps.map(map => map.hash);
 
@@ -244,7 +246,7 @@ export class LocalMapsManagerService {
     public async exportMaps(version: BSVersion, maps: BsmLocalMap[], outPath: string){
 
         const archive = new Archive(outPath);
-        
+
         if(!maps || maps.length === 0){
             const mapsFolder = await this.getMapsFolderPath(version);
             archive.addDirectory(mapsFolder, false);


### PR DESCRIPTION
On linux only exactly Info.dat was matched, and many maps use different casing.

<!--

Please use the content below as a template for your pull request.
Feel free to remove sections which do not make sense.

-->

## Scope

Fixes map downloads on linux.

<!-- Brief description of WHAT you’re doing and WHY. -->

## Implementation

This just gets all files, and finds info.dat by comparing lowercase strings.
Slightly inefficient on windows, but I think a consistent implementation is worth it.

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## How to Test

Download random maps on linux, previously that would throw errors quickly, since the casing was wrong.
Now it works without issues.
<!--

A straightforward scenario of how to test your changes could help colleagues that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Notes

I can remove the formatting changes, but it's a bit annoying since my IDE autoformats and I have to sleep.
I can make a PR with automatic formatting checks with prettier and eslint if that is of interest.

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

| | | |
| --- | --- | --- |
| Blocking | 🔴 ❌ 🚨 | RED |
| Non-blocking | 🟡 💡 🤔 💭 | Yellow, thinking, etc |
| Praise | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
