### PR TITLE
[bugfix] Ensure BSInstances exist before running depotdownloader

### DIFF
--- a/src/main/services/bs-installer.service.ts
+++ b/src/main/services/bs-installer.service.ts
@@ -7,7 +7,7 @@ import log from "electron-log";
 import { InstallationLocationService } from "./installation-location.service";
 import { BSLocalVersionService } from "./bs-local-version.service";
 import { WindowManagerService } from "./window-manager.service";
-import { copy } from "fs-extra";
+import { copy, ensureDir } from "fs-extra";
 import { pathExist } from "../helpers/fs.helpers";
 import { Observable, map } from "rxjs";
 import { DepotDownloaderArgsOptions, DepotDownloaderErrorEvent, DepotDownloaderEvent, DepotDownloaderEventType, DepotDownloaderInfoEvent } from "../../shared/models/depot-downloader.model";
@@ -77,12 +77,14 @@ export class BSInstallerService {
             qr
         }
 
+        await ensureDir(this.installLocationService.versionsDirectory);
+
         return new DepotDownloader({
             command: this.getDepotDownloaderExePath(),
             args: DepotDownloader.buildArgs(depotDownloaderOptions),
             options: { cwd: this.installLocationService.versionsDirectory },
             echoStartData: downloadVersion
-        });
+        }, log);
     }
 
     private buildDepotDownloaderObservable(downloadInfos: DownloadInfo, qr?: boolean): Observable<DepotDownloaderEvent> {


### PR DESCRIPTION
Fix :
```
Unhandled Exception Error: spawn C:\Users\user\AppData\Local\Programs\bs-manager\resources\assets\scripts\depot-downloader\DepotDownloader.exe ENOENT
    at Process.ChildProcess._handle.onexit (node:internal/child_process:283:19)
    at onErrorNT (node:internal/child_process:476:16)
    at processTicksAndRejections (node:internal/process/task_queues:82:21)
```