### PR TITLE
Fix Depot Downloader not working on Linux

### DIFF
--- a/src/main/services/bs-installer.service.ts
+++ b/src/main/services/bs-installer.service.ts
@@ -47,7 +47,9 @@ export class BSInstallerService {
 
     public async isDotNet6Installed(): Promise<boolean> {
         try {
-            const proc = spawnSync(`${process.platform === 'linux' ? 'dotnet ' : ''}${this.getDepotDownloaderExePath()}`);
+           const proc = process.platform === 'linux'
+                ? spawnSync('dotnet', [this.getDepotDownloaderExePath()])
+                : spawnSync(this.getDepotDownloaderExePath());
             if (proc.stderr?.toString()) {
                 log.error("no dotnet", proc.stderr.toString());
                 return false;
@@ -84,8 +86,8 @@ export class BSInstallerService {
         const args = DepotDownloader.buildArgs(depotDownloaderOptions);
 
         return new DepotDownloader({
-            command: isLinux ? 'dotnet' : this.getDepotDownloaderExePath(),
-            args: isLinux ? [exePath, ...args] : [exePath],
+            command: isLinux ? 'dotnet' : exePath,
+            args: isLinux ? [exePath, ...args] : args,
             options: { cwd: this.installLocationService.versionsDirectory },
             echoStartData: downloadVersion
         }, log);
@@ -110,7 +112,7 @@ export class BSInstallerService {
                     }
                     return event;
                 })).subscribe(sub);
-                
+
             }).catch(err => sub.error({
                 type: DepotDownloaderEventType.Error,
                 subType: DepotDownloaderErrorEvent.Unknown,


### PR DESCRIPTION
## Scope

Fixes the Depot Downloader not functioning on Linux.
This should be double-checked to ensure Windows compatibility is not affected.

## Implementation

Instead of directly invoking the exe, it will run the DLL through dotnet when Linux is detected.

## How to Test

- Try downloading a version of Beat Saber on Linux and Windows.

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
