### PR TITLE
Skip Liv initialization on Linux

### DIFF
--- a/src/main/services/liv/liv.service.ts
+++ b/src/main/services/liv/liv.service.ts
@@ -25,7 +25,8 @@ export class LivService {
             win32: async () => {
                 const regRes = await regedit.promisified.list([this.livRegeditKey]).then(res => res[this.livRegeditKey]);
                 return regRes?.exists;
-            }
+            },
+            linux: async() => false,
         });
     }
 

--- a/src/main/services/liv/liv.service.ts
+++ b/src/main/services/liv/liv.service.ts
@@ -20,14 +20,13 @@ export class LivService {
 
     }
 
-    public isLivInstalled(): Promise<boolean> {
+    public async isLivInstalled(): Promise<boolean> {
         return execOnOs({
             win32: async () => {
                 const regRes = await regedit.promisified.list([this.livRegeditKey]).then(res => res[this.livRegeditKey]);
                 return regRes?.exists;
             },
-            linux: async() => false,
-        });
+        }, true);
     }
 
     public async createLivShortcut(entry: LivEntry): Promise<void> {


### PR DESCRIPTION
<!--

Please use the content below as a template for your pull request.
Feel free to remove sections which do not make sense.

-->

## Scope

<!-- Brief description of WHAT you’re doing and WHY. -->

As of 46eb8d0, when launching the application on Linux it would immediately crash due to there not being an implementation of `#isLivInstalled` for Linux.

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

To fix this, I've simply added a Linux implementation that always returns false.

## How to Test

Try launching the application at/after 46eb8d0 with and without this patch.

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
