### PR TITLE
[bugfix] BS version page being downloaded was always recognized as a Steam version, preventing launching if it was an Oculus version

### DIFF
--- a/src/main/services/bs-launcher/abstract-launcher.service.ts
+++ b/src/main/services/bs-launcher/abstract-launcher.service.ts
@@ -2,6 +2,7 @@ import { LaunchOption } from "shared/models/bs-launch";
 import { BSLocalVersionService } from "../bs-local-version.service";
 import { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio, spawn } from "child_process";
 import path from "path";
+import log from "electron-log";
 
 export abstract class AbstractLauncherService {
     
@@ -38,6 +39,8 @@ export abstract class AbstractLauncherService {
         if(args.includes("--verbose")){
             spawnOptions.windowsVerbatimArguments = true;
         }
+
+        log.info(`Launch BS exe at ${bsExePath} with args ${args?.join(" ")}`);
 
         return spawn(bsExePath, args, spawnOptions);
 

--- a/src/main/services/bs-version-download/bs-oculus-downloader.service.ts
+++ b/src/main/services/bs-version-download/bs-oculus-downloader.service.ts
@@ -108,7 +108,11 @@ export class BsOculusDownloaderService {
     private async createDownloadVersion(version: BSVersion): Promise<{version: BSVersion, dest: string}>{
         const dest = await ensurePathNotAlreadyExist(await this.versions.getVersionPath(version));
         return {
-            version: {...version, ...(path.basename(dest) !== version.BSVersion && { name: path.basename(dest) })},
+            version: {
+                ...version, 
+                ...(path.basename(dest) !== version.BSVersion && { name: path.basename(dest) }),
+                metadata: { store: BsStore.OCULUS }
+            },
             dest
         };
     }

--- a/src/main/services/bs-version-download/bs-steam-downloader.service.ts
+++ b/src/main/services/bs-version-download/bs-steam-downloader.service.ts
@@ -64,7 +64,11 @@ export class BsSteamDownloaderService {
 
         const versionPath = await this.localVersionService.getVersionPath(downloadInfos.bsVersion);
         const dest = downloadInfos.isVerification ? versionPath : await ensurePathNotAlreadyExist(versionPath);
-        const downloadVersion: BSVersion = { ...downloadInfos.bsVersion, ...(path.basename(dest) !== downloadInfos.bsVersion.BSVersion && { name: path.basename(dest) }) };
+        const downloadVersion: BSVersion = {
+            ...downloadInfos.bsVersion,
+            ...(path.basename(dest) !== downloadInfos.bsVersion.BSVersion && { name: path.basename(dest) }),
+            metadata: { store: BsStore.STEAM }
+        };
 
         const depotDownloaderOptions: DepotDownloaderArgsOptions = {
             app: BS_APP_ID,


### PR DESCRIPTION
BS version page being downloaded was always recognized as a Steam version, preventing launching if it was an Oculus version

(The bug occurs if staying on the same BS version page during its download then launching it without having changed page)