### PR TITLE
Bugfix/handle oculus library doesnt have originalpath

### DIFF
--- a/src/main/helpers/fs.helpers.ts
+++ b/src/main/helpers/fs.helpers.ts
@@ -6,6 +6,7 @@ import log from "electron-log";
 import { BsmException } from "shared/models/bsm-exception.model";
 import crypto from "crypto";
 import { execSync } from "child_process";
+import { tryit } from "../../shared/helpers/error.helpers";
 
 export async function pathExist(path: string): Promise<boolean> {
     try {
@@ -234,18 +235,12 @@ export async function isJunction(path: string): Promise<boolean>{
 }
 
 export function resolveGUIDPath(guidPath: string): string {
-    log.info("resolveGUIDPath", guidPath);
     const guidVolume = path.parse(guidPath).root;
-    log.info("guidVolume", guidVolume);
     const command = `powershell -command "(Get-WmiObject -Class Win32_Volume | Where-Object { $_.DeviceID -like '${guidVolume}' }).DriveLetter"`;
-    log.info("command", command);
-    const driveLetter = execSync(command).toString().trim();
-    log.info("driveLetter", driveLetter);
-    if (!driveLetter) {
-        log.error("Unable to resolve GUID path");
-        throw new Error("Unable to resolve GUID path");
+    const {result: driveLetter, error} = tryit(() => execSync(command).toString().trim());
+    if (!driveLetter || error) {
+        throw new Error("Unable to resolve GUID path", error);
     }
-    log.info("result guid", path.join(driveLetter, path.relative(guidVolume, guidPath)));
     return path.join(driveLetter, path.relative(guidVolume, guidPath));
 }
 

--- a/src/main/services/bs-launcher/oculus-launcher.service.ts
+++ b/src/main/services/bs-launcher/oculus-launcher.service.ts
@@ -35,7 +35,6 @@ export class OculusLauncherService extends AbstractLauncherService implements St
 
         this.oculus.tryGetGameFolder([OCULUS_BS_DIR, OCULUS_BS_BACKUP_DIR]).then(async dirPath => {
             if(dirPath){
-                log.info("Oculus game found", dirPath);
                 return this.oculusLib$.next( path.join(dirPath, "..") );
             }
             const defaultLib = ((await this.oculus.getOculusLibs()) || []).find(lib => lib.isDefault);
@@ -51,7 +50,6 @@ export class OculusLauncherService extends AbstractLauncherService implements St
         const oculusLibPath = await lastValueFrom(this.oculusLib$.pipe(take(1), timeout(sToMs(30)), catchError(() => of(null))));
 
         if(!oculusLibPath || !(await pathExists(oculusLibPath))){
-            log.error("oculusLibPath value", oculusLibPath, "Path exists", await pathExists(oculusLibPath));
             throw new Error("Oculus library not found, deleteBsSymlinks");
         }
 

--- a/src/main/services/bs-launcher/oculus-launcher.service.ts
+++ b/src/main/services/bs-launcher/oculus-launcher.service.ts
@@ -34,7 +34,10 @@ export class OculusLauncherService extends AbstractLauncherService implements St
         this.pathsService = InstallationLocationService.getInstance();
 
         this.oculus.tryGetGameFolder([OCULUS_BS_DIR, OCULUS_BS_BACKUP_DIR]).then(async dirPath => {
-            if(dirPath){ return this.oculusLib$.next( path.join(dirPath, "..") ); }
+            if(dirPath){
+                log.info("Oculus game found", dirPath);
+                return this.oculusLib$.next( path.join(dirPath, "..") );
+            }
             const defaultLib = ((await this.oculus.getOculusLibs()) || []).find(lib => lib.isDefault);
             if(defaultLib?.path){ return this.oculusLib$.next(path.join(defaultLib.path, "Software")); }
             this.oculusLib$.next(null);
@@ -48,6 +51,7 @@ export class OculusLauncherService extends AbstractLauncherService implements St
         const oculusLibPath = await lastValueFrom(this.oculusLib$.pipe(take(1), timeout(sToMs(30)), catchError(() => of(null))));
 
         if(!oculusLibPath || !(await pathExists(oculusLibPath))){
+            log.error("oculusLibPath value", oculusLibPath, "Path exists", await pathExists(oculusLibPath));
             throw new Error("Oculus library not found, deleteBsSymlinks");
         }
 

--- a/src/main/services/oculus.service.ts
+++ b/src/main/services/oculus.service.ts
@@ -32,13 +32,7 @@ export class OculusService {
         const oculusLibsRegKey = "HKCU\\SOFTWARE\\Oculus VR, LLC\\Oculus\\Libraries";
         const libsRegData = await list(oculusLibsRegKey).then(data => data[oculusLibsRegKey]);
 
-        log.info("Oculus libraries registry data", "exists:", libsRegData.exists, "keys:", "values:", libsRegData.keys, (() => {
-            const values = Object.entries(libsRegData.values ?? []);
-            return values.map(([name, value]) => [name, value.value]);
-        })());
-
         if (!libsRegData.keys?.length) {
-            log.info("Registry key \"HKCU\\SOFTWARE\\Oculus VR, LLC\\Oculus\\Libraries\" not found");
             return null;
         }
 
@@ -47,11 +41,6 @@ export class OculusService {
         const libsPath: OculusLibrary[] = (
             await Promise.all(libsRegData.keys.map(async key => {
                 const originalPath = await list([`${oculusLibsRegKey}\\${key}`]).then(res => res[`${oculusLibsRegKey}\\${key}`]);
-
-                log.info("Value in key", key, "is", (() => {
-                    const values = Object.entries(originalPath.values ?? []);
-                    return values.map(([name, value]) => [name, value.value]);
-                })());
                 
                 if (originalPath.values?.OriginalPath) {
                     return { id: key, path: originalPath.values.OriginalPath.value, isDefault: defaultLibraryId === key } as OculusLibrary;
@@ -97,7 +86,6 @@ export class OculusService {
     public async tryGetGameFolder(gameFolders: string[]): Promise<string> {
         for(const gameFolder of gameFolders){
             const fullPath = await this.getGameFolder(gameFolder);
-            log.info("Oculus game folder", gameFolder, "fullPath", fullPath);
             if(fullPath){ return fullPath; }
         }
 

--- a/src/main/services/oculus.service.ts
+++ b/src/main/services/oculus.service.ts
@@ -33,6 +33,7 @@ export class OculusService {
         const libsRegData = await list(oculusLibsRegKey).then(data => data[oculusLibsRegKey]);
 
         if (!libsRegData.keys?.length) {
+            log.info("Registry key \"HKCU\\SOFTWARE\\Oculus VR, LLC\\Oculus\\Libraries\" not found");
             return null;
         }
 


### PR DESCRIPTION
Handle when Oculus library doesn't have the `OriginalPath` value in the registry but only the `Path` value which is an GUID path.