### PR TITLE
Fix BSIPA not running on Linux

### DIFF
--- a/src/main/services/mods/bs-mods-manager.service.ts
+++ b/src/main/services/mods/bs-mods-manager.service.ts
@@ -155,8 +155,13 @@ export class BsModsManagerService {
         }
 
         return new Promise<boolean>(resolve => {
-            log.info("START IPA PROCESS", `start /wait /min "" "${ipaPath}" ${args.join(" ")}`);
-            const processIPA = spawn(`start /wait /min "" "${ipaPath}" ${args.join(" ")}`, { cwd: versionPath, detached: true, shell: true });
+            const cmd = process.platform === 'linux'
+                ? `screen -dmS "BSIPA" dotnet ${ipaPath} ${args.join(" ")}` // Must run through screen, otherwise BSIPA tries to move console cursor and crashes.
+                : `start /wait /min "" "${ipaPath}" ${args.join(" ")}`;
+
+            log.info("START IPA PROCESS", cmd);
+            const processIPA = spawn(cmd, { cwd: versionPath, detached: true, shell: true });
+
             processIPA.once("exit", code => {
                 if (code === 0) {
                     log.info("Ipa process exist with code 0");
@@ -230,7 +235,7 @@ export class BsModsManagerService {
                 log.error("Error while extracting mod zip", e);
                 return false;
             });
-        
+
         log.info("Mod zip extraction end", mod.name, "to", destDir, "success:", extracted);
 
         const res = isBSIPA


### PR DESCRIPTION
<!--

Please use the content below as a template for your pull request.
Feel free to remove sections which do not make sense.

-->

## Scope

Fixes the inability to install mods under Linux due to BSIPA being executed with Windows-specific parameters.
Closes #440.

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

When running on Linux, BSIPA is now run with dotnet in a screen session. The screen session is a hack. However, it's required since BSIPA tries to move the console cursor, which doesn't exist in our environment, and crashes with an ArgumentOutOfRangeException before exiting. Running it in a screen session fixes this problem.

## How to Test

<!--

A straightforward scenario of how to test your changes could help colleagues that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

- Try installing mods on Linux

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
