### PR TITLE
Fix Steam elevated check on Linux

### DIFF
--- a/src/main/services/steam.service.ts
+++ b/src/main/services/steam.service.ts
@@ -52,7 +52,6 @@ export class SteamService {
      * @returns true if the Steam process is running as administrator
      */
     public async isElevated(): Promise<boolean>{
-        if(process.platform === "linux"){ return true; }
         const steamPid = await this.getSteamPid();
 
         if(!steamPid){ return false; }


### PR DESCRIPTION
<!--

Please use the content below as a template for your pull request.
Feel free to remove sections which do not make sense.

-->

I see the v1.5.0 branch is what's currently active so I've targeted this PR to that. Let me know if you'd like it on master and I'll rebase.

## Scope

<!-- Brief description of WHAT you’re doing and WHY. -->
This removes the forced skip of the elevated check for Steam on Linux.
Steam should never be running as admin on Linux, so defaulting to true doesn't make sense, and the existing isElevated check appears to be working correctly.

<!--

A straightforward scenario of how to test your changes could help colleagues that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
