### PR TITLE
Clearer English translation for Steam Credentials popup

### DIFF
--- a/assets/jsons/translations/en.json
+++ b/assets/jsons/translations/en.json
@@ -550,8 +550,8 @@
         },
         "steam-credentials": {
             "title": "Steam Credentials",
-            "p-1": "The credentials are only used to download the game because steam need to verify that you paid the game in order to be allowed to download it. They aren't saved and directly passed to DepotDownloader. If you don't want to enter your credentials you can follow this tutorial :",
-            "p-2": "and then click on the gear icon in the top right corner and select \"Import a version\", select the folder where beat saber has been downloaded (If you follow the tutorial above you should have the correct location)"
+            "p-1": "Your Steam credentials are only required to download versions of Beat Saber, we use DepotDownloader to achieve this which requires your Steam credentials to verify that you own the game within your library before allowing you to retrieve the game files, your credentials are not stored or saved and are passed directly to DepotDownloader. However, if you don't want to do that, you can follow this tutorial instead: ",
+            "p-2": "Afterwards you can click on the gear icon in the top right corner and select \"Import a version\", then you can select the folder where Beat Saber was downloaded to. (If you followed the tutorial, you will have the right location)"
         },
         "bs-import-version": {
             "title": "Import a version",


### PR DESCRIPTION
## Scope

The changes below show a clearer sentence structure for outlying why users are required to input their credentials to download prior versions of Beat Saber, how their credentials are being used and ensuring users are aware that their Steam credentials are only being used through DepotDownloader. I found the previous translation to be poorly written with improper grammar, this should clear up confusions with future users.

All other translations if not properly worded by their translators for the Steam Credentials popup will need to be updated as well alongside or after this PR.

## How to Test

Build a new version with this PR and check the English translations within the Steam Credentials popup.

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |