### PR TITLE
[bugfix] Reimplement 30 sec timeout on BS launches.

### DIFF
--- a/src/main/services/bs-launcher/abstract-launcher.service.ts
+++ b/src/main/services/bs-launcher/abstract-launcher.service.ts
@@ -58,6 +58,12 @@ export abstract class AbstractLauncherService {
                 log.info(`BS process exit with code ${code}`);
                 resolve(code);
             });
+
+            setTimeout(() => {
+                process.removeAllListeners("error");
+                process.removeAllListeners("exit");
+                resolve(-1);
+            }, 30_000);
         });
 
         return { process, exit };


### PR DESCRIPTION
## Scope

Re-implemented 30 second timeout on launchBs to allow shortcut to close before BS is closed.

[Bug reported on Discord](https://discord.com/channels/1049624409276694588/1236234526729043979)

> Shortcut "Launching Beat Saber" window remains open as long as Beat Saber is open, closing immediately when BS is closed.