### PR TITLE
[bugfix] exclude regedit-rs on externals when webpack bundles it in linux

### DIFF
--- a/.erb/configs/webpack.config.base.ts
+++ b/.erb/configs/webpack.config.base.ts
@@ -6,8 +6,20 @@ import webpack from "webpack";
 import webpackPaths from "./webpack.paths";
 import { dependencies as externals } from "../../release/app/package.json";
 
+function createExternals(): string[] {
+    const webpackExternals: string[] = [...Object.keys(externals || {})];
+    const excludedExternals: string[] = [];
+
+    if (process.platform === "linux") {
+        // Linux only uses regedit-rs types
+        excludedExternals.push("regedit-rs");
+    }
+
+    return webpackExternals.filter(external => !excludedExternals.includes(external));
+}
+
 const configuration: webpack.Configuration = {
-    externals: [...Object.keys(externals || {})],
+    externals: createExternals(),
 
     stats: "errors-only",
 


### PR DESCRIPTION
## Scope

[closes TICKET-546](https://github.com/Zagrios/bs-manager/issues/546)

## Implementation

Issue was that when **webpack** bundles the project and **[name].bundle.dev.js** was executed, `require('regedit-rs')` was being called, producing the error in the ticket.

![image](https://github.com/user-attachments/assets/a6fa3662-8b89-4fd6-8f60-02d4d7ee9325)

Resolution was to exclude `regedit-rs` within the webpack config `external` property.

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
