### PR TITLE
Fix Steam elevated check on Linux

### DIFF
--- a/src/main/services/steam.service.ts
+++ b/src/main/services/steam.service.ts
@@ -52,7 +52,6 @@ export class SteamService {
      * @returns true if the Steam process is running as administrator
      */
     public async isElevated(): Promise<boolean>{
-        if(process.platform === "linux"){ return true; }
         const steamPid = await this.getSteamPid();
 
         if(!steamPid){ return false; }


### PR DESCRIPTION
This is exactly the same as #449, as it seems like it got reverted at some point.