### PR TITLE
[bugfix] wrap dotnet cmdlet's path argument with double quotes for installing bsipa

### DIFF
--- a/src/main/services/mods/bs-mods-manager.service.ts
+++ b/src/main/services/mods/bs-mods-manager.service.ts
@@ -147,7 +147,7 @@ export class BsModsManagerService {
 
         return new Promise<boolean>(resolve => {
             const cmd = process.platform === 'linux'
-                ? `screen -dmS "BSIPA" dotnet ${ipaPath} ${args.join(" ")}` // Must run through screen, otherwise BSIPA tries to move console cursor and crashes.
+                ? `screen -dmS "BSIPA" dotnet "${ipaPath}" ${args.join(" ")}` // Must run through screen, otherwise BSIPA tries to move console cursor and crashes.
                 : `"${ipaPath}" ${args.join(" ")}`;
 
             log.info("START IPA PROCESS", cmd);


### PR DESCRIPTION
## Scope

Custom version name breaks installing BSIPA mod in linux. Eg. version name is `1.29.1 (Test)`

```
1] 21:30:07.182 › START IPA PROCESS screen -dmS "BSIPA" dotnet /home/<username>/BSManager/BSInstances/1.29.1 (Test 1)/IPA.exe -n
[1] 21:30:07.198 › IPA process stderr /bin/sh: -c: line 1: syntax error near unexpected token `('
[1] /bin/sh: -c: line 1: `screen -dmS "BSIPA" dotnet /home/<username>/BSManager/BSInstances/1.29.1 (Test 1)/IPA.exe -n'
[1] 
[1] 21:30:07.199 › Ipa process exist with non 0 code 2
[1] 21:30:07.199 › Error: Unable to install BSIPA
[1]     at BsModsManagerService.installMods (/home/<username>/Desktop/Beat_Saber/bs-manager/.erb/dll/main.bundle.dev.js:149365:66)
[1]     at process.processTicksAndRejections (node:internal/process/task_queues:95:5) cannot-install-bsipa
```

## How to Test

Requirements: Uninstall BSIPA on the version you are testing.

1. Rename a version to an invalid name. Eg. `1.29.1 (Test)`.
2. Toggle checkbox to ON on BSIPA mod.
3. Click on install.

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
