### PR TITLE
[bugfix] use static config for version list in linux

### DIFF
--- a/src/main/services/static-configuration.service.ts
+++ b/src/main/services/static-configuration.service.ts
@@ -1,5 +1,6 @@
 import ElectronStore from "electron-store";
 import { Observable } from "rxjs";
+import { BSVersion } from "shared/bs-version.interface";
 
 export class StaticConfigurationService {
     private static instance: StaticConfigurationService;
@@ -53,6 +54,7 @@ export class StaticConfigurationService {
 }
 
 export interface StaticConfigKeyValues {
+    "versions": BSVersion[];
     "installation-folder": string;
     "song-details-cache-etag": string;
     "disable-hadware-acceleration": boolean;


### PR DESCRIPTION
## How to Test

Publish with linux and run the `.AppImage` build file. Following error log should not be visible anymore.

```
[2024-09-10 00:17:21.799] [error] Unhandled Exception UnhandledRejection Error: EROFS: read-only file system, open '/tmp/.mount_<any>/resources/assets/jsons/bs-versions.json'
    at writeFileSync (node:fs:2368:20)
    at updateLocalVersions (/tmp/.mount_<any>/resources/app.asar/dist/main/main.js:14:1151852)
    at u.loadBsVersions (/tmp/.mount_<any>/resources/app.asar/dist/main/main.js:14:1152117)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at u.getAvailableVersions (/tmp/.mount_<any>/resources/app.asar/dist/main/main.js:14:1152212)
```

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
