### PR TITLE
[bugfix] handle undefined modal options properly

### DIFF
--- a/src/renderer/components/modal/modal.component.tsx
+++ b/src/renderer/components/modal/modal.component.tsx
@@ -17,7 +17,7 @@ export function Modal() {
 
     useEffect(() => {
         const onEscape = (e: KeyboardEvent) => {
-            if (currentModal.options.closable === false || e.key !== "Escape") {
+            if (currentModal.options?.closable === false || e.key !== "Escape") {
                 return;
             }
             currentModal.resolver({ exitCode: ModalExitCode.CLOSED });
@@ -65,7 +65,7 @@ export function Modal() {
     }
 
     const onOverlayClicked = () => {
-        if (currentModal.options.closable === false) {
+        if (currentModal.options?.closable === false) {
             return;
         }
 


### PR DESCRIPTION
## Scope

If the modal options is not defined the ff. error is reported. Just handled it in the code so that the check is done properly.

```
[2024-09-21 12:06:03.298] [error] [
  [
    "Uncaught TypeError: Cannot read properties of undefined (reading 'closable')",
    'file:///C:/Users/<user>/AppData/Local/Programs/bs-manager/resources/app.asar/dist/renderer/renderer.js',
    2,
    2311860,
    "Error: Cannot read properties of undefined (reading 'closable')"
  ]
]
```

## How to Test

Open the modal for downloading a BS Version.

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
