### PR TITLE
[feat-543] added notification when logging out

### DIFF
--- a/assets/jsons/translations/de.json
+++ b/assets/jsons/translations/de.json
@@ -120,6 +120,7 @@
                 "title": "Steam & Oculus",
                 "description": "Das Abmelden ermöglicht es dir, beim nächsten Download von Beat Saber den Account zu wechseln.",
                 "logout": "Abmelden",
+                "logout-success": "Logout Successful",
                 "download-platform": {
                     "title": "Standardplattform",
                     "desc": "Wähle die Standardplattform, die für das Herunterladen von Beat Saber-Versionen verwendet werden soll.",

--- a/assets/jsons/translations/de.json
+++ b/assets/jsons/translations/de.json
@@ -120,7 +120,7 @@
                 "title": "Steam & Oculus",
                 "description": "Das Abmelden ermöglicht es dir, beim nächsten Download von Beat Saber den Account zu wechseln.",
                 "logout": "Abmelden",
-                "logout-success": "Logout Successful",
+                "logout-success": "Abmeldung erfolgreich",
                 "download-platform": {
                     "title": "Standardplattform",
                     "desc": "Wähle die Standardplattform, die für das Herunterladen von Beat Saber-Versionen verwendet werden soll.",

--- a/assets/jsons/translations/en.json
+++ b/assets/jsons/translations/en.json
@@ -120,6 +120,7 @@
                 "title": "Steam & Oculus",
                 "description": "Logging out will allow you to switch accounts on the next Beat Saber download.",
                 "logout": "Log out",
+                "logout-success": "Logout Successful",
                 "download-platform": {
                     "title": "Default Platform",
                     "desc": "Choose the default platform that will be used to download versions of Beat Saber.",

--- a/assets/jsons/translations/es.json
+++ b/assets/jsons/translations/es.json
@@ -120,6 +120,7 @@
                 "title": "Steam & Oculus",
                 "description": "Desconectarte te permitirá cambiar de cuenta en la próxima descarga de Beat Saber.",
                 "logout": "Cerrar sesión",
+                "logout-success": "Logout Successful",
                 "download-platform": {
                     "title": "Plataforma predeterminada",
                     "desc": "Elige la plataforma predeterminada que se utilizará para descargar las versiones de Beat Saber.",

--- a/assets/jsons/translations/es.json
+++ b/assets/jsons/translations/es.json
@@ -120,7 +120,7 @@
                 "title": "Steam & Oculus",
                 "description": "Desconectarte te permitirá cambiar de cuenta en la próxima descarga de Beat Saber.",
                 "logout": "Cerrar sesión",
-                "logout-success": "Logout Successful",
+                "logout-success": "Cierre de sesión exitoso",
                 "download-platform": {
                     "title": "Plataforma predeterminada",
                     "desc": "Elige la plataforma predeterminada que se utilizará para descargar las versiones de Beat Saber.",

--- a/assets/jsons/translations/fr.json
+++ b/assets/jsons/translations/fr.json
@@ -120,6 +120,7 @@
                 "title": "Steam & Oculus",
                 "description": "Te déconnecter te permettra de changer de compte au prochain téléchargement de Beat Saber.",
                 "logout": "Déconnexion",
+                "logout-success": "Logout Successful",
                 "download-platform": {
                     "title": "Plateforme par défaut",
                     "desc": "Choisi la plateforme par défaut qui sera utilisée pour télécharger les versions de Beat Saber.",

--- a/assets/jsons/translations/fr.json
+++ b/assets/jsons/translations/fr.json
@@ -120,7 +120,7 @@
                 "title": "Steam & Oculus",
                 "description": "Te déconnecter te permettra de changer de compte au prochain téléchargement de Beat Saber.",
                 "logout": "Déconnexion",
-                "logout-success": "Logout Successful",
+                "logout-success": "Déconnexion réussie",
                 "download-platform": {
                     "title": "Plateforme par défaut",
                     "desc": "Choisi la plateforme par défaut qui sera utilisée pour télécharger les versions de Beat Saber.",

--- a/assets/jsons/translations/ja.json
+++ b/assets/jsons/translations/ja.json
@@ -120,6 +120,7 @@
                 "title": "Steam & Oculus",
                 "description": "ログアウトすると、次のBeat Saberダウンロード時にアカウントを切り替えることができます。",
                 "logout": "ログアウト",
+                "logout-success": "Logout Successful",
                 "download-platform": {
                     "title": "デフォルトプラットフォーム",
                     "desc": "Beat Saberのダウンロードに使用するデフォルトのプラットフォームを選択します。",

--- a/assets/jsons/translations/ja.json
+++ b/assets/jsons/translations/ja.json
@@ -120,7 +120,7 @@
                 "title": "Steam & Oculus",
                 "description": "ログアウトすると、次のBeat Saberダウンロード時にアカウントを切り替えることができます。",
                 "logout": "ログアウト",
-                "logout-success": "Logout Successful",
+                "logout-success": "ログアウト成功",
                 "download-platform": {
                     "title": "デフォルトプラットフォーム",
                     "desc": "Beat Saberのダウンロードに使用するデフォルトのプラットフォームを選択します。",

--- a/assets/jsons/translations/ru.json
+++ b/assets/jsons/translations/ru.json
@@ -120,6 +120,7 @@
                 "title": "Steam & Oculus",
                 "description": "Выход позволит вам сменить учетную запись при следующей загрузке Beat Saber.",
                 "logout": "Выйти",
+                "logout-success": "Logout Successful",
                 "download-platform": {
                     "title": "Основная платформа",
                     "desc": "Выберите основную платформу, которая будет использоваться для скачивания версий Beat Saber.",

--- a/assets/jsons/translations/ru.json
+++ b/assets/jsons/translations/ru.json
@@ -120,7 +120,7 @@
                 "title": "Steam & Oculus",
                 "description": "Выход позволит вам сменить учетную запись при следующей загрузке Beat Saber.",
                 "logout": "Выйти",
-                "logout-success": "Logout Successful",
+                "logout-success": "Выход выполнен успешно",
                 "download-platform": {
                     "title": "Основная платформа",
                     "desc": "Выберите основную платформу, которая будет использоваться для скачивания версий Beat Saber.",

--- a/assets/jsons/translations/zh-tw.json
+++ b/assets/jsons/translations/zh-tw.json
@@ -120,6 +120,7 @@
                 "title": "Steam & Oculus",
                 "description": "登出後，您可以在下一次下載 Beat Saber 時切換帳戶。",
                 "logout": "登出",
+                "logout-success": "Logout Successful",
                 "download-platform": {
                     "title": "，預設平台",
                     "desc": "選擇要下載 BeatSaber 的預設平台。",

--- a/assets/jsons/translations/zh-tw.json
+++ b/assets/jsons/translations/zh-tw.json
@@ -120,7 +120,7 @@
                 "title": "Steam & Oculus",
                 "description": "登出後，您可以在下一次下載 Beat Saber 時切換帳戶。",
                 "logout": "登出",
-                "logout-success": "Logout Successful",
+                "logout-success": "登出成功",
                 "download-platform": {
                     "title": "，預設平台",
                     "desc": "選擇要下載 BeatSaber 的預設平台。",

--- a/assets/jsons/translations/zh.json
+++ b/assets/jsons/translations/zh.json
@@ -120,6 +120,7 @@
                 "title": "Steam & Oculus",
                 "description": "登出后，您可以在下一次下载 Beat Saber 时切换帐户。",
                 "logout": "登出",
+                "logout-success": "Logout Successful",
                 "download-platform": {
                     "title": "，默认平台",
                     "desc": "选择要下载 BeatSaber 的默认平台。",

--- a/assets/jsons/translations/zh.json
+++ b/assets/jsons/translations/zh.json
@@ -120,7 +120,7 @@
                 "title": "Steam & Oculus",
                 "description": "登出后，您可以在下一次下载 Beat Saber 时切换帐户。",
                 "logout": "登出",
-                "logout-success": "Logout Successful",
+                "logout-success": "注销成功",
                 "download-platform": {
                     "title": "，默认平台",
                     "desc": "选择要下载 BeatSaber 的默认平台。",

--- a/src/renderer/pages/settings-page.component.tsx
+++ b/src/renderer/pages/settings-page.component.tsx
@@ -136,7 +136,14 @@ export function SettingsPage() {
     }
 
     const clearDownloadersSession = () => {
+        if (!hasDownloaderSession) {
+            return;
+        }
+
         steamDownloader.deleteSteamSession();
+        notificationService.notifyInfo({
+            title: "pages.settings.steam-and-oculus.logout-success",
+        });
         loadDownloadersSession();
     }
 


### PR DESCRIPTION

## Scope

Should prompt a successful notification when user logouts. 

[closes TICKET-543](https://github.com/Zagrios/bs-manager/issues/543)

## How to Test

* Login to the app, or directly inject a username within the electronjs renderer.
```js
localStorage.setItem("STEAM-USERNAME", "<any username>");
```
* Go to the settings page and logout
* Notification should show.

## New Resource Text

**pages.settings.steam-and-oculus.logout-success:** Logout Successful

## Additional Comments

**notifications.settings.steam.success.titles.logout** seems to be unused. Maybe this can be removed.

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
