### PR TITLE
[bugfix] show bsm icon properly

### DIFF
--- a/src/main/services/utils.service.ts
+++ b/src/main/services/utils.service.ts
@@ -8,7 +8,12 @@ import log from "electron-log";
 export class UtilsService {
     private static instance: UtilsService;
 
-    private assetsPath: string = app.isPackaged ? path.join(process.resourcesPath, "assets") : path.join(__dirname, "../../assets");
+    private assetsPath: string = app.isPackaged
+        ? path.join(process.resourcesPath, "assets")
+        : path.join(path.dirname(path.dirname(__dirname)), "assets");
+    private readonly buildPath: string = app.isPackaged
+        ? path.join(process.resourcesPath, "build")
+        : path.join(path.dirname(path.dirname(__dirname)), "build");
 
     private constructor() {}
 
@@ -34,6 +39,10 @@ export class UtilsService {
     }
     public getTempPath(): string {
         return path.join(app.getPath("temp"), app.getName());
+    }
+
+    public getBuildPath(filepath: string): string {
+        return path.join(this.buildPath, filepath);
     }
 
     public ipcSend<T = unknown>(channel: string, response: IpcResponse<T>): void {

--- a/src/main/services/window-manager.service.ts
+++ b/src/main/services/window-manager.service.ts
@@ -25,7 +25,9 @@ export class WindowManagerService {
 
     private readonly baseWindowOption: BrowserWindowConstructorOptions = {
         title: APP_NAME,
-        icon: this.utilsService.getAssetsPath("favicon.ico"),
+        icon: process.platform === "linux"
+            ? this.utilsService.getBuildPath(path.join("icons", "png", "256x256.png"))
+            : this.utilsService.getBuildPath(path.join("icons", "win", "favicon.ico")),
         show: false,
         frame: false,
         titleBarOverlay: false,


### PR DESCRIPTION
## Scope

Correctly point to icon images for both windows and linux

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
