### PR TITLE
[bugfix-585] fixed unicode song titles not showing in game

### DIFF
--- a/src/main/services/bs-launcher/steam-launcher.service.ts
+++ b/src/main/services/bs-launcher/steam-launcher.service.ts
@@ -140,6 +140,8 @@ export class SteamLauncherService extends AbstractLauncherService implements Sto
                     "STEAM_COMPAT_INSTALL_PATH": bsFolderPath,
                     "STEAM_COMPAT_CLIENT_INSTALL_PATH": steamPath,
                     "STEAM_COMPAT_APP_ID": BS_APP_ID,
+                    // Run game in steam environment; fixes #585 for unicode song titles
+                    "SteamEnv": "1",
                     // Uncomment these to create a proton log file in the Beat Saber install directory.
                     // "PROTON_LOG": 1,
                     // "PROTON_LOG_DIR": bsFolderPath,


### PR DESCRIPTION
## Scope

closes https://github.com/Zagrios/bs-manager/issues/585

## Implementation

Added SteamEnv=1 in environment variable when launching the `Beat Saber.exe` file

## How to Test

Download any song in BSManager with any unicode character. Sample maps to download:

* みにまむ - misterlihao
* ツユ - アンダーヒロイン - wangyufy

**Check if they are visible in game.**

_**Check if downloading maps in game will properly work as well.**_

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
