### PR TITLE
[chore] added discord link in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+lank_issues_enabled: true
+contact_links:
+    - name: Discord Support
+      url: https://discord.gg/uSqbHVpKdV
+      about: You can join our Discord server for a quick and interactive support.


### PR DESCRIPTION
To reduce trivial / non-complex issues to be posted as github issues.

![image](https://github.com/user-attachments/assets/eafe544e-bb53-4993-bf0e-dbc4fe6a02c0)

_**NOTE: about wording is different on the commit**_