### PR TITLE
[bugfix] Fixed all errors from depotdownloader was unknown errors

### DIFF
--- a/src/main/services/bs-version-download/bs-steam-downloader.service.ts
+++ b/src/main/services/bs-version-download/bs-steam-downloader.service.ts
@@ -12,6 +12,7 @@ import { DepotDownloaderArgsOptions, DepotDownloaderErrorEvent, DepotDownloaderE
 import { DepotDownloader } from "../../models/depot-downloader.class";
 import { app } from "electron";
 import { BsStore } from "../../../shared/models/bs-store.enum";
+import { CustomError } from "shared/models/exceptions/custom-error.class";
 
 export class BsSteamDownloaderService {
     private static instance: BsSteamDownloaderService;
@@ -96,7 +97,7 @@ export class BsSteamDownloaderService {
                 depotDownloader.$events().pipe(
                     map(event => {
                         if(event.type === DepotDownloaderEventType.Error){
-                            throw event;
+                            throw new CustomError(JSON.stringify(event.data) ?? "An error occur in the DepotDownloader process", event?.subType ?? DepotDownloaderErrorEvent.Unknown, event)
                         }
                         return event;
                     }),

--- a/src/renderer/components/modal/modal-types/bs-downgrade/login-to-steam-modal.component.tsx
+++ b/src/renderer/components/modal/modal-types/bs-downgrade/login-to-steam-modal.component.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "renderer/hooks/use-translation.hook";
 import { ModalComponent, ModalExitCode, ModalService } from "renderer/services/modale.service";
 import { WhySteamCredentialsModal } from "./why-steam-credentials-modal.component";
 import { useService } from "renderer/hooks/use-service.hook";
-import { Observable } from "rxjs";
+import { catchError, Observable, of } from "rxjs";
 import { useObservable } from "renderer/hooks/use-observable.hook";
 import { QRCodeSVG } from "qrcode.react";
 import { BsmCheckbox } from "renderer/components/shared/bsm-checkbox.component";
@@ -21,7 +21,7 @@ export const LoginToSteamModal: ModalComponent<
     const [password, setPassword] = useState("");
     const [stay, setStay] = useState(false);
     const [showPassword, setShowPassword] = useState(false);
-    const qrCodeUrl = useObservable(() => data.qrCode$);
+    const qrCodeUrl = useObservable(() => data.qrCode$.pipe(catchError(() => of(null))));
     const t = useTranslation();
 
     useEffect(() => {

--- a/src/renderer/services/bs-version-download/steam-downloader.service.ts
+++ b/src/renderer/services/bs-version-download/steam-downloader.service.ts
@@ -13,6 +13,7 @@ import { SteamMobileApproveModal } from "renderer/components/modal/modal-types/b
 import { DownloaderServiceInterface } from "./bs-store-downloader.interface";
 import { AbstractBsDownloaderService } from "./abstract-bs-downloader.service";
 import { addFilterStringLog } from "renderer";
+import { CustomError } from "shared/models/exceptions/custom-error.class";
 
 export class SteamDownloaderService extends AbstractBsDownloaderService implements DownloaderServiceInterface{
 
@@ -120,11 +121,11 @@ export class SteamDownloaderService extends AbstractBsDownloaderService implemen
         return subs;
     }
 
-    private hanndleErrorEvent(errorEvent: DepotDownloaderEvent) {
+    private hanndleErrorEvent(errorEvent: CustomError) {
         const handledErrors = Object.values(DepotDownloaderErrorEvent);
 
-        if(handledErrors.includes(errorEvent?.subType as DepotDownloaderErrorEvent)){
-            return this.notificationService.notifyError({title: "notifications.types.error", desc: `notifications.bs-download.steam-download.errors.msg.${errorEvent.subType}`, duration: 10_000});
+        if(handledErrors.includes(errorEvent?.code as DepotDownloaderErrorEvent)){
+            return this.notificationService.notifyError({title: "notifications.types.error", desc: `notifications.bs-download.steam-download.errors.msg.${errorEvent.code}`, duration: 10_000});
         }
 
         return this.notificationService.notifyError({title: "notifications.types.error", desc: `notifications.bs-download.steam-download.errors.msg.${DepotDownloaderErrorEvent.Unknown}`, duration: 10_000});


### PR DESCRIPTION
All errors from DepotDownloader were displayed as 'Unknown error' due to the serialization/deserialization of errors
\+ handle qr code errors in the login modal