### PR TITLE
[bugfix] Unable to load bsm's files if path to bsm contain url special chars

### DIFF
--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -1,17 +1,15 @@
 /* eslint import/prefer-default-export: off, import/no-mutable-exports: off */
-import { URL } from "url";
+import { pathToFileURL, URL } from "url";
 import path from "path";
 
-export let resolveHtmlPath: (htmlFileName: string) => string;
-
-if (process.env.NODE_ENV === "development") {
-    const port = process.env.PORT || 1212;
-    resolveHtmlPath = (htmlFileName: string) => {
+export function resolveHtmlPath (htmlFileName: string) {
+    if (process.env.NODE_ENV === "development") {
+        const port = process.env.PORT || 1212;
         const url = new URL(`http://localhost:${port}/${htmlFileName}`);
         return url.toString();
-    };
-} else {
-    resolveHtmlPath = (htmlFileName: string) => {
-        return `file://${path.resolve(__dirname, "../renderer/", htmlFileName)}`;
-    };
-}
+    }
+    const filePath = path.resolve(__dirname, "..", "renderer", htmlFileName);
+    return pathToFileURL(filePath).toString();
+};
+
+


### PR DESCRIPTION
If the path to the BSManager installation contained URL special characters, like `C:\User\My#User\..\bs-manager`
BSManager was unable to locate its files