### PR TITLE
[bugfix-452] fix to "launch game when steam is not running" on linux

### DIFF
--- a/src/main/services/steam.service.ts
+++ b/src/main/services/steam.service.ts
@@ -13,7 +13,9 @@ const { list } = (execOnOs({ win32: () => require("regedit-rs") }, true) ?? {}) 
 
 export class SteamService {
 
-    private static readonly PROCESS_NAME = "steam";
+    private static readonly PROCESS_NAME: string = process.platform === "linux"
+        ? "steam-runtime-launcher-service"
+        : "steam";
 
     private static instance: SteamService;
 

--- a/src/main/services/steam.service.ts
+++ b/src/main/services/steam.service.ts
@@ -116,7 +116,7 @@ export class SteamService {
 
     public async openSteam(): Promise<void> {
 
-        await shell.openPath("steam://open/games");
+        await shell.openExternal("steam://open/games");
 
         return new Promise((resolve, reject) => {
             // Every 3 seconds check if steam is running


### PR DESCRIPTION
Closes #452 

Fixes issue of steam not launching when it is not already open. Also flatpak now launches Beat Saber as expected