### PR TITLE
Use correct beatsaver api url

### DIFF
--- a/src/main/services/thrid-party/beat-saver/beat-saver-api.service.ts
+++ b/src/main/services/thrid-party/beat-saver/beat-saver-api.service.ts
@@ -15,7 +15,7 @@ export class BeatSaverApiService {
 
     private readonly request: RequestService;
 
-    private readonly bsaverApiUrl = "https://beatsaver.com/api";
+    private readonly bsaverApiUrl = "https://api.beatsaver.com";
 
     private constructor() {
         this.request = RequestService.getInstance();


### PR DESCRIPTION
External api requests should be made to the api.beatsaver.com subdomain.