### PR TITLE
Pass query parameters to playlist downloader

### DIFF
--- a/src/main/services/additional-content/local-playlists-manager.service.ts
+++ b/src/main/services/additional-content/local-playlists-manager.service.ts
@@ -69,8 +69,8 @@ export class LocalPlaylistsManagerService {
         this.deepLink.addLinkOpenedListener(this.DEEP_LINKS.BeatSaver, link => {
             log.info("DEEP-LINK RECEIVED FROM", this.DEEP_LINKS.BeatSaver, link);
             const url = new URL(link);
-            const bplistUrl = url.host === "playlist" ? url.pathname.replace("/", "") : "";
-            this.windows.openWindow(`oneclick-download-playlist.html?playlistUrl=${bplistUrl}`);
+            const bplistUrl = url.host === "playlist" ? url.pathname.replace("/", "") + url.search : "";
+            this.windows.openWindow(`oneclick-download-playlist.html?playlistUrl=${encodeURIComponent(bplistUrl)}`);
         });
 
         this.fileAssociation.registerFileAssociation(".bplist", filePath => {


### PR DESCRIPTION
## Scope

Pass query parameters from playlist oneclick handler to the service that downloads the playlist.

### Example:
`bsplaylist://playlist/https://api.beatsaver.com/playlists/id/12272/download?exp=1733163270&sig=db9ba0699986f368`

Currently this would be stripped to: `https://api.beatsaver.com/playlists/id/12272/download`
But after this change the exp and sig fields don't get removed and oneclick just works™️

## Screenshots

| before | after |
| ------ | ----- |
| <img width="383" alt="Screenshot 2024-12-02 at 18 21 28" src="https://github.com/user-attachments/assets/4aaea5a0-f4fc-4209-be88-8689292d9963"> | <img width="427" alt="Screenshot 2024-12-02 at 18 26 03" src="https://github.com/user-attachments/assets/c1c07229-3741-4189-ab52-8f0dc19df3a4"> |

## How to Test

- Go to https://beatsaver.com
- Make a private playlist or bookmark a map
- Try to one click install it
