### PR TITLE
[bugfix] change linux shell from /bin/bash to bash

### DIFF
--- a/src/main/helpers/os.helpers.ts
+++ b/src/main/helpers/os.helpers.ts
@@ -41,8 +41,8 @@ function updateCommand(command: string, options: BsmSpawnOptions) {
 
     if (process.platform === "linux") {
         // "/bin/sh" does not see flatpak-spawn
-        // Most Debian and Arch should also support "/bin/bash"
-        options.options.shell = "/bin/bash";
+        // All distros should support "bash" by default
+        options.options.shell = "bash";
 
         if (options.linux?.prefix) {
             command = `${options.linux.prefix} ${command}`;


### PR DESCRIPTION
Just used default `bash` rather than absolute `/bin/bash` to get the correct shell from all distros.