### PR TITLE
[feat] add proton logs in advance launch settings for linux

### DIFF
--- a/assets/jsons/translations/de.json
+++ b/assets/jsons/translations/de.json
@@ -56,7 +56,9 @@
                 "skipsteam": "Steam überspringen",
                 "skipsteam-description": "Verhindert, dass Steam automatisch mit Beat Saber geöffnet wird. Aktivieren Sie dies, wenn Sie eine andere VR-Laufzeit wie WiVRn oder Monado verwenden, mit der SteamVR interferieren könnte.",
                 "map-editor": "Karteneditor",
-                "map-editor-description": "Starte den offiziellen Beat Saber-Karteneditor anstelle des Spiels."
+                "map-editor-description": "Starte den offiziellen Beat Saber-Karteneditor anstelle des Spiels.",
+                "proton-logs": "Proton-Logs",
+                "proton-logs-description": "Aktiviert die Aufzeichnung von Proton-Logs für diese Beat Saber-Installation auf \"{versionPath}\"."
             },
             "maps": {
                 "search-bar": {

--- a/assets/jsons/translations/en.json
+++ b/assets/jsons/translations/en.json
@@ -56,7 +56,9 @@
                 "skipsteam": "Skip Steam",
                 "skipsteam-description": "Stops Steam from opening automatically with Beat Saber, enable if you are using a different VR runtime like WiVRn or Monado that SteamVR may interfere with.",
                 "map-editor": "Map Editor",
-                "map-editor-description": "Start the official Beat Saber map editor instead of the game."
+                "map-editor-description": "Start the official Beat Saber map editor instead of the game.",
+                "proton-logs": "Proton Logs",
+                "proton-logs-description": "Writes the proton logs within the Beat Saber version. To access logs, go to \"Version Settings ⚙️ > Open Folder > Open `Logs` Folder\"."
             },
             "maps": {
                 "search-bar": {

--- a/assets/jsons/translations/en.json
+++ b/assets/jsons/translations/en.json
@@ -58,7 +58,7 @@
                 "map-editor": "Map Editor",
                 "map-editor-description": "Start the official Beat Saber map editor instead of the game.",
                 "proton-logs": "Proton Logs",
-                "proton-logs-description": "Writes the proton logs within the Beat Saber version. To access logs, go to \"Version Settings ⚙️ > Open Folder > Open `Logs` Folder\"."
+                "proton-logs-description": "Enables the recording of proton logs for this Beat Saber install to \"{versionPath}\"."
             },
             "maps": {
                 "search-bar": {

--- a/assets/jsons/translations/es.json
+++ b/assets/jsons/translations/es.json
@@ -52,7 +52,13 @@
                 "advanced-launch": {
                     "button": "Opciones de lanzamiento",
                     "placeholder": "Argumentos adicionales ej: --revert; --no-wait"
-                }
+                },
+                "skipsteam": "Saltar Steam",
+                "skipsteam-description": "Evita que Steam se abra automáticamente con Beat Saber, habilita esto si estás usando un runtime de VR diferente como WiVRn o Monado que SteamVR podría interferir.",
+                "map-editor": "Editor de mapas",
+                "map-editor-description": "Inicia el editor oficial de mapas de Beat Saber en lugar del juego.",
+                "proton-logs": "Registros de Proton",
+                "proton-logs-description": "Habilita el registro de los logs de Proton para esta instalación de Beat Saber en \"{versionPath}\"."
             },
             "maps": {
                 "search-bar": {
@@ -62,11 +68,7 @@
                         "export-maps": "Exportar mapas",
                         "delete-maps": "Borrar mapas",
                         "delete-duplicate-maps": "Borrar duplicados"
-                    },
-                    "skipsteam": "Saltar Steam",
-                    "skipsteam-description": "Evita que Steam se abra automáticamente con Beat Saber, habilita esto si estás usando un runtime de VR diferente como WiVRn o Monado que SteamVR podría interferir.",
-                    "map-editor": "Editor de mapas",
-                    "map-editor-description": "Inicia el editor oficial de mapas de Beat Saber en lugar del juego."
+                    }
                 },
                 "tabs": {
                     "maps": {

--- a/assets/jsons/translations/fr.json
+++ b/assets/jsons/translations/fr.json
@@ -56,7 +56,9 @@
                 "skipsteam": "Ignorer Steam",
                 "skipsteam-description": "Empêche Steam de s'ouvrir automatiquement avec Beat Saber, activez-le si vous utilisez un autre runtime VR comme WiVRn ou Monado avec lequel SteamVR pourrait interférer.",
                 "map-editor": "Éditeur de map",
-                "map-editor-description": "Lance l'éditeur officiel de map de Beat Saber au lieu du jeu."
+                "map-editor-description": "Lance l'éditeur officiel de map de Beat Saber au lieu du jeu.",
+                "proton-logs": "Journaux de Proton",
+                "proton-logs-description": "Active l'enregistrement des journaux Proton pour cette installation de Beat Saber sur \"{versionPath}\"."
             },
             "maps": {
                 "search-bar": {

--- a/assets/jsons/translations/ja.json
+++ b/assets/jsons/translations/ja.json
@@ -54,7 +54,11 @@
                     "placeholder": "追加引数 例：--revert; --nowait"
                 },
                 "skipsteam": "Steamをスキップ",
-                "skipsteam-description": "Beat Saberと一緒にSteamが自動的に開くのを防ぎます。SteamVRが干渉する可能性のあるWiVRnやMonadoなど、別のVRランタイムを使用している場合は有効にしてください。"
+                "skipsteam-description": "Beat Saberと一緒にSteamが自動的に開くのを防ぎます。SteamVRが干渉する可能性のあるWiVRnやMonadoなど、別のVRランタイムを使用している場合は有効にしてください。",
+                "map-editor": "マップエディタ",
+                "map-editor-description": "ゲームの代わりに公式のBeat Saberマップエディタを起動する。",
+                "proton-logs": "プロトンログ",
+                "proton-logs-description": "このBeat Saberインストールのプロトンログの記録を「{versionPath}」に有効にします。"
             },
             "maps": {
                 "search-bar": {

--- a/assets/jsons/translations/ko.json
+++ b/assets/jsons/translations/ko.json
@@ -56,7 +56,9 @@
                 "skipsteam": "Steam 실행 건너뛰기",
                 "skipsteam-description": "Beat Saber와 함께 Steam이 자동으로 열리는 것을 방지합니다. SteamVR이 간섭할 수 있는 WiVRn 또는 Monado와 같은 다른 VR 런타임을 사용하는 경우 활성화하세요.",
                 "map-editor": "맵 편집기",
-                "map-editor-description": "게임 대신 공식 Beat Saber 맵 편집기를 실행해."
+                "map-editor-description": "게임 대신 공식 Beat Saber 맵 편집기를 실행해.",
+                "proton-logs": "프로톤 로그",
+                "proton-logs-description": "이 Beat Saber 설치에 대한 프로톤 로그 기록을 「{versionPath}」로 활성화합니다."
             },
             "maps": {
                 "search-bar": {

--- a/assets/jsons/translations/ru.json
+++ b/assets/jsons/translations/ru.json
@@ -56,7 +56,9 @@
                 "skipsteam": "Пропустить Steam",
                 "skipsteam-description": "Предотвращает автоматическое открытие Steam с Beat Saber, включите, если вы используете другую VR-среду, такую как WiVRn или Monado, с которой SteamVR может мешать.",
                 "map-editor": "Редактор карт",
-                "map-editor-description": "Запусти официальный редактор карт Beat Saber вместо игры."
+                "map-editor-description": "Запусти официальный редактор карт Beat Saber вместо игры.",
+                "proton-logs": "Протонные логи",
+                "proton-logs-description": "Включает запись протонных логов для этой установки Beat Saber в \"{versionPath}\"."
             },
             "maps": {
                 "search-bar": {

--- a/assets/jsons/translations/zh-tw.json
+++ b/assets/jsons/translations/zh-tw.json
@@ -56,7 +56,9 @@
                 "skipsteam": "跳過 Steam",
                 "skipsteam-description": "防止 Steam 與 Beat Saber 自動打開，如果您使用的是其他 VR 執行時，如 WiVRn 或 Monado，SteamVR 可能會干擾，請啟用此選項。",
                 "map-editor": "地圖編輯器",
-                "map-editor-description": "啟動官方的 Beat Saber 地圖編輯器，而不是遊戲。"
+                "map-editor-description": "啟動官方的 Beat Saber 地圖編輯器，而不是遊戲。",
+                "proton-logs": "Proton紀錄",
+                "proton-logs-description": "啟用此 Beat Saber 安裝的質子紀錄，路徑為\"{versionPath}\"。"
             },
             "maps": {
                 "search-bar": {

--- a/assets/jsons/translations/zh.json
+++ b/assets/jsons/translations/zh.json
@@ -56,7 +56,9 @@
                 "skipsteam": "跳过 Steam",
                 "skipsteam-description": "防止 Steam 与 Beat Saber 自动打开，如果您使用的是其他 VR 运行时，如 WiVRn 或 Monado，SteamVR 可能会干扰，请启用此选项。",
                 "map-editor": "地图编辑器",
-                "map-editor-description": "启动官方的 Beat Saber 地图编辑器，而不是游戏。"
+                "map-editor-description": "启动官方的 Beat Saber 地图编辑器，而不是游戏。",
+                "proton-logs": "Proton日志",
+                "proton-logs-description": "启用此 Beat Saber 安装的质子日志，路径为\"{versionPath}\"。"
             },
             "maps": {
                 "search-bar": {

--- a/src/main/services/bs-launcher/bs-launcher.service.ts
+++ b/src/main/services/bs-launcher/bs-launcher.service.ts
@@ -131,6 +131,7 @@ export class BSLauncherService {
         if(launchOptions.launchMods?.includes(LaunchMods.DEBUG)){ res.debug = "true"; }
         if(launchOptions.additionalArgs){ res.additionalArgs = launchOptions.additionalArgs; }
         if(launchOptions.launchMods?.includes(LaunchMods.SKIP_STEAM)){ res.skipSteam = "true"; }
+        if(launchOptions.launchMods?.includes(LaunchMods.PROTON_LOGS)){ res.protonLogs = "true"; }
 
         return res;
     }
@@ -248,6 +249,7 @@ type ShortcutParams = {
     debug?: string;
     additionalArgs?: string[];
     skipSteam?: string;
+    protonLogs?: string;
     version: string;
     versionName?: string;
     versionIno?: string;

--- a/src/main/services/linux.service.ts
+++ b/src/main/services/linux.service.ts
@@ -6,6 +6,7 @@ import { StaticConfigurationService } from "./static-configuration.service";
 import { CustomError } from "shared/models/exceptions/custom-error.class";
 import { BSLaunchError, LaunchOption } from "shared/models/bs-launch";
 import { bsmExec } from "main/helpers/os.helpers";
+import { LaunchMods } from "shared/models/bs-launch/launch-option.interface";
 
 export class LinuxService {
     private static instance: LinuxService;
@@ -78,11 +79,15 @@ export class LinuxService {
             "STEAM_COMPAT_CLIENT_INSTALL_PATH": steamPath,
             "STEAM_COMPAT_APP_ID": BS_APP_ID,
             // Run game in steam environment; fixes #585 for unicode song titles
-            "SteamEnv": "1",
-            // Uncomment these to create a proton log file in the Beat Saber install directory.
-            // "PROTON_LOG": 1,
-            // "PROTON_LOG_DIR": bsFolderPath,
+            "SteamEnv": 1,
         });
+
+        if (launchOptions.launchMods?.includes(LaunchMods.PROTON_LOGS)) {
+            Object.assign(env, {
+                "PROTON_LOG": 1,
+                "PROTON_LOG_DIR": path.join(bsFolderPath, "Logs"),
+            });
+        }
     }
 
     public verifyProtonPath(protonFolder: string = ""): boolean {

--- a/src/renderer/components/version-viewer/slides/launch/launch-mod-toogle.component.tsx
+++ b/src/renderer/components/version-viewer/slides/launch/launch-mod-toogle.component.tsx
@@ -22,7 +22,7 @@ export function LaunchModToogle({ onClick, active, text, icon: Icon, infoText }:
                 {Icon && <Icon className="h-7 shrink-0 text-gray-800 dark:text-white" />}
                 <span className="w-fit min-w-fit text-lg font-bold uppercase tracking-wide italic ">{t(text)}</span>
                 {infoText && (
-                    <Tippy content={t(infoText)} placement="top" theme="default" delay={[400, 0]}>
+                    <Tippy content={t(infoText)} className="break-words" placement="bottom" delay={[400, 0]}>
                         <div className="h-[25px] w-[25px] shrink-0 p-1.5 rounded-full cursor-help bg-light-main-color-1 dark:bg-main-color-3 hover:brightness-110">
                             <BsmIcon className="w-full h-full" icon="info" />
                         </div>

--- a/src/renderer/components/version-viewer/slides/launch/launch-mod-toogle.component.tsx
+++ b/src/renderer/components/version-viewer/slides/launch/launch-mod-toogle.component.tsx
@@ -2,7 +2,7 @@ import Tippy from "@tippyjs/react";
 import { GlowEffect } from "renderer/components/shared/glow-effect.component";
 import { BsmIcon } from "renderer/components/svgs/bsm-icon.component";
 import { SvgIcon } from "renderer/components/svgs/svg-icon.type";
-import { useTranslation } from "renderer/hooks/use-translation.hook";
+import { useTranslationV2 } from "renderer/hooks/use-translation.hook";
 
 type Props = {
     onClick: (active: boolean) => void;
@@ -13,7 +13,7 @@ type Props = {
 };
 
 export function LaunchModToogle({ onClick, active, text, icon: Icon, infoText }: Props) {
-    const t = useTranslation();
+    const { text: t } = useTranslationV2();
 
     return (
         <button className={`shrink-0 relative rounded-full cursor-pointer group active:scale-95 transition-transform ${!active && "shadow-md shadow-black"}`} onClick={() => onClick(!active)}>

--- a/src/renderer/components/version-viewer/slides/launch/launch-mod-toogle.component.tsx
+++ b/src/renderer/components/version-viewer/slides/launch/launch-mod-toogle.component.tsx
@@ -22,7 +22,7 @@ export function LaunchModToogle({ onClick, active, text, icon: Icon, infoText }:
                 {Icon && <Icon className="h-7 shrink-0 text-gray-800 dark:text-white" />}
                 <span className="w-fit min-w-fit text-lg font-bold uppercase tracking-wide italic ">{t(text)}</span>
                 {infoText && (
-                    <Tippy content={t(infoText)} className="break-words" placement="bottom" delay={[400, 0]}>
+                    <Tippy content={t(infoText)} className="break-words" placement="top" theme="default" delay={[200, 0]}>
                         <div className="h-[25px] w-[25px] shrink-0 p-1.5 rounded-full cursor-help bg-light-main-color-1 dark:bg-main-color-3 hover:brightness-110">
                             <BsmIcon className="w-full h-full" icon="info" />
                         </div>

--- a/src/renderer/components/version-viewer/slides/launch/launch-options-panel.component.tsx
+++ b/src/renderer/components/version-viewer/slides/launch/launch-options-panel.component.tsx
@@ -52,7 +52,7 @@ export function LaunchModItem({ id, icon: Icon, label, description, active, visi
     const { text: t } = useTranslationV2();
 
     return (
-        <Tippy theme="default" placement="top" content={description}>
+        <Tippy theme="default" className="break-words" placement="top" content={description}>
             <button id={id} className={cn("grow rounded-md bg-theme-1 relative flex justify-center items-center h-10 py-1 px-3", visible === false && "hidden")} onClick={e => { e.preventDefault(); e.stopPropagation(); onChange?.(!active) }}>
                 <BsmCheckbox className="h-4 aspect-square z-[1] relative mr-1.5" checked={active} onChange={onChange}/>
                 {Icon && <Icon className="h-full w-fit py-0.5 mr-1.5"/>}

--- a/src/renderer/components/version-viewer/slides/launch/launch-slide.component.tsx
+++ b/src/renderer/components/version-viewer/slides/launch/launch-slide.component.tsx
@@ -71,6 +71,13 @@ export function LaunchSlide({ version }: Props) {
         : setPinnedLaunchMods(prev => prev.filter(mod => mod !== launchMod));
 
     useEffect(() => {
+        let protonLogsPath: string[] = [];
+        if (window.electron.platform === "linux") {
+            protonLogsPath = version.steam
+                ? [version.path, "Logs"]
+                : ["BSInstances", version.name, "Logs"];
+        }
+
         setLaunchModItems(() => [
             {
                 id: LaunchMods.OCULUS,
@@ -126,7 +133,9 @@ export function LaunchSlide({ version }: Props) {
             {
                 id: LaunchMods.PROTON_LOGS,
                 label: t("pages.version-viewer.launch-mods.proton-logs"),
-                description: t("pages.version-viewer.launch-mods.proton-logs-description"),
+                description: t("pages.version-viewer.launch-mods.proton-logs-description", {
+                    versionPath: `${window.electron.path.join(...protonLogsPath)}/`
+                }),
                 active: activeLaunchMods.includes(LaunchMods.PROTON_LOGS),
                 pinned: pinnedLaunchMods.includes(LaunchMods.PROTON_LOGS),
                 visible: window.electron.platform === "linux",

--- a/src/renderer/components/version-viewer/slides/launch/launch-slide.component.tsx
+++ b/src/renderer/components/version-viewer/slides/launch/launch-slide.component.tsx
@@ -62,6 +62,14 @@ export function LaunchSlide({ version }: Props) {
         }
     }, [activeLaunchMods]);
 
+    const toggleActiveLaunchMod = (checked: boolean, launchMod: LaunchMod) => checked
+        ? setActiveLaunchMods(prev => [...prev, launchMod])
+        : setActiveLaunchMods(prev => prev.filter(mod => mod !== launchMod));
+
+    const togglePinnedLaunchMod = (pinned: boolean, launchMod: LaunchMod) => pinned
+        ? setPinnedLaunchMods(prev => [...prev, launchMod])
+        : setPinnedLaunchMods(prev => prev.filter(mod => mod !== launchMod));
+
     useEffect(() => {
         setLaunchModItems(() => [
             {
@@ -72,8 +80,8 @@ export function LaunchSlide({ version }: Props) {
                 active: activeLaunchMods.includes(LaunchMods.OCULUS),
                 visible: !(version.metadata?.store === BsStore.OCULUS),
                 pinned: pinnedLaunchMods.includes(LaunchMods.OCULUS),
-                onChange: checked => checked ? setActiveLaunchMods(prev => [...prev, LaunchMods.OCULUS]) : setActiveLaunchMods(prev => prev.filter(mod => mod !== LaunchMods.OCULUS)),
-                onPinChange: pinned => pinned ? setPinnedLaunchMods(prev => [...prev, LaunchMods.OCULUS]) : setPinnedLaunchMods(prev => prev.filter(mod => mod !== LaunchMods.OCULUS)),
+                onChange: (checked) => toggleActiveLaunchMod(checked, LaunchMods.OCULUS),
+                onPinChange: (pinned) => togglePinnedLaunchMod(pinned, LaunchMods.OCULUS),
             },
             {
                 id: LaunchMods.FPFC,
@@ -82,8 +90,8 @@ export function LaunchSlide({ version }: Props) {
                 description: t("pages.version-viewer.launch-mods.desktop-description"),
                 active: activeLaunchMods.includes(LaunchMods.FPFC),
                 pinned: pinnedLaunchMods.includes(LaunchMods.FPFC),
-                onChange: checked => checked ? setActiveLaunchMods(prev => [...prev, LaunchMods.FPFC]) : setActiveLaunchMods(prev => prev.filter(mod => mod !== LaunchMods.FPFC)),
-                onPinChange: pinned => pinned ? setPinnedLaunchMods(prev => [...prev, LaunchMods.FPFC]) : setPinnedLaunchMods(prev => prev.filter(mod => mod !== LaunchMods.FPFC)),
+                onChange: (checked) => toggleActiveLaunchMod(checked, LaunchMods.FPFC),
+                onPinChange: (pinned) => togglePinnedLaunchMod(pinned, LaunchMods.FPFC),
             },
             {
                 id: LaunchMods.DEBUG,
@@ -92,8 +100,8 @@ export function LaunchSlide({ version }: Props) {
                 description: t("pages.version-viewer.launch-mods.debug-description"),
                 active: activeLaunchMods.includes(LaunchMods.DEBUG),
                 pinned: pinnedLaunchMods.includes(LaunchMods.DEBUG),
-                onChange: checked => checked ? setActiveLaunchMods(prev => [...prev, LaunchMods.DEBUG]) : setActiveLaunchMods(prev => prev.filter(mod => mod !== LaunchMods.DEBUG)),
-                onPinChange: pinned => pinned ? setPinnedLaunchMods(prev => [...prev, LaunchMods.DEBUG]) : setPinnedLaunchMods(prev => prev.filter(mod => mod !== LaunchMods.DEBUG)),
+                onChange: (checked) => toggleActiveLaunchMod(checked, LaunchMods.DEBUG),
+                onPinChange: (pinned) => togglePinnedLaunchMod(pinned, LaunchMods.DEBUG),
             },
             {
                 id: LaunchMods.SKIP_STEAM,
@@ -101,8 +109,8 @@ export function LaunchSlide({ version }: Props) {
                 description: t("pages.version-viewer.launch-mods.skipsteam-description"),
                 active: activeLaunchMods.includes(LaunchMods.SKIP_STEAM),
                 pinned: pinnedLaunchMods.includes(LaunchMods.SKIP_STEAM),
-                onChange: checked => checked ? setActiveLaunchMods(prev => [...prev, LaunchMods.SKIP_STEAM]) : setActiveLaunchMods(prev => prev.filter(mod => mod !== LaunchMods.SKIP_STEAM)),
-                onPinChange: pinned => pinned ? setPinnedLaunchMods(prev => [...prev, LaunchMods.SKIP_STEAM]) : setPinnedLaunchMods(prev => prev.filter(mod => mod !== LaunchMods.SKIP_STEAM)),
+                onChange: (checked) => toggleActiveLaunchMod(checked, LaunchMods.SKIP_STEAM),
+                onPinChange: (pinned) => togglePinnedLaunchMod(pinned, LaunchMods.SKIP_STEAM),
             },
             {
                 id: LaunchMods.EDITOR,
@@ -112,14 +120,23 @@ export function LaunchSlide({ version }: Props) {
                 active: activeLaunchMods.includes(LaunchMods.EDITOR),
                 pinned: pinnedLaunchMods.includes(LaunchMods.EDITOR),
                 visible: !safeLt(version.BSVersion, "1.23.0"),
-                onChange: checked => checked ? setActiveLaunchMods(prev => [...prev, LaunchMods.EDITOR]) : setActiveLaunchMods(prev => prev.filter(mod => mod !== LaunchMods.EDITOR)),
-                onPinChange: pinned => pinned ? setPinnedLaunchMods(prev => [...prev, LaunchMods.EDITOR]) : setPinnedLaunchMods(prev => prev.filter(mod => mod !== LaunchMods.EDITOR)),
-
-            }
+                onChange: (checked) => toggleActiveLaunchMod(checked, LaunchMods.EDITOR),
+                onPinChange: (pinned) => togglePinnedLaunchMod(pinned, LaunchMods.EDITOR),
+            },
+            {
+                id: LaunchMods.PROTON_LOGS,
+                label: t("pages.version-viewer.launch-mods.proton-logs"),
+                description: t("pages.version-viewer.launch-mods.proton-logs-description"),
+                active: activeLaunchMods.includes(LaunchMods.PROTON_LOGS),
+                pinned: pinnedLaunchMods.includes(LaunchMods.PROTON_LOGS),
+                visible: window.electron.platform === "linux",
+                onChange: (checked) => toggleActiveLaunchMod(checked, LaunchMods.PROTON_LOGS),
+                onPinChange: (pinned) => togglePinnedLaunchMod(pinned, LaunchMods.PROTON_LOGS),
+            },
         ]);
     }, [activeLaunchMods, pinnedLaunchMods, version]);
 
-    const launch = () => {
+    const launch = async () => {
         const additionalArgs = additionalArgsString?.split(";").map(arg => arg.trim()).filter(arg => arg.length > 0);
 
         const launch$ = bsLauncherService.launch({
@@ -193,5 +210,3 @@ export function LaunchSlide({ version }: Props) {
         </div>
     );
 }
-
-

--- a/src/renderer/services/i18n.service.ts
+++ b/src/renderer/services/i18n.service.ts
@@ -5,6 +5,7 @@ import { ConfigurationService } from "./configuration.service";
 import { getProperty } from "dot-prop";
 import { i18n } from "dateformat";
 import { createElement, Fragment } from "react";
+import { logRenderError } from "renderer";
 
 export class I18nService {
     private static instance: I18nService;
@@ -79,7 +80,13 @@ export class I18nService {
     public translate(translationKey: string, args?: Record<string, string>): string {
         let translated = this.cache.get(translationKey);
         if (!translated) {
-            translated = getProperty(this.dictionary, translationKey) ?? translationKey;
+            try {
+                translated = getProperty(this.dictionary, translationKey) ?? translationKey;
+            } catch (error) {
+                // Invalid translationKey like strings containing "[]"
+                logRenderError(`Could not get property of ${translationKey}`, error);
+                translated = translationKey;
+            }
             this.cache.set(translationKey, translated);
         }
 

--- a/src/shared/models/bs-launch/launch-option.interface.ts
+++ b/src/shared/models/bs-launch/launch-option.interface.ts
@@ -6,6 +6,7 @@ export const LaunchMods = {
     DEBUG: "debug",
     SKIP_STEAM: "skip_steam",
     EDITOR: "editor",
+    PROTON_LOGS: "proton_logs",
 } as const;
 
 export type LaunchMod = typeof LaunchMods[keyof typeof LaunchMods];


### PR DESCRIPTION
Added a way write the proton logs within the BS version "Logs" folder.

As of https://github.com/Zagrios/bs-manager/pull/708/commits/6b5ccfe08b3b74819401e03d88e4dd6a7bfe4c10
![image](https://github.com/user-attachments/assets/7d407e5c-3762-41f0-864c-7a3a6abf4a6c)

![image](https://github.com/user-attachments/assets/3ee14301-9eb7-445f-b15f-fb2f9067de22)

**Texts**
proton-logs: Proton Logs
proton-logs-description: Enables the recording of proton logs for this Beat Saber install to "{versionPath}".