### PR TITLE
[chore] added instruction for adding logs in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yaml
@@ -26,7 +26,8 @@ body:
       id: replication
       attributes:
         label: Steps to Reproduce
-        description: Provide a link to a live example, or an unambiguous set of steps to reproduce this bug. Include code to reproduce, if relevant.
+        description: Provide a link to a live example, or an unambiguous set of steps to reproduce this bug.
+            Include code to reproduce, if relevant.
         placeholder: |
             1. Go to '...'
             2. Click on '....'
@@ -50,5 +51,6 @@ body:
       id: additional-context
       attributes:
         label: Additional Context
-        description: Any other context that you may share about the issue. You may add your log files here.
+        description: Any other context that you may share about the issue such as logs.
+            To get the logs, follow these steps `Open BSManager -> Go to settings -> Scroll down -> Open Logs`.
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-lank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
     - name: Discord Support
       url: https://discord.gg/uSqbHVpKdV


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0e6d92ba-0db7-417d-b391-9d3f7b091b41)
NOTE: Not sure if adding a separate field for log files is better than just having it being dropped in the addition content textarea field

### Disabled submitting blank issues

**Rationale:** so we can force users to use the templates which has also have instruction on adding log files to reduce issue turn over time if possible.