### PR TITLE
Update flatpak dependencies to non-EOL versions

### DIFF
--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -51,6 +51,10 @@ const config = {
         fpm: ["--after-install=build/after-install.sh"],
     },
     flatpak: {
+        // Version of org.electronjs.Electron2.BaseApp
+        baseVersion: "24.08",
+        // Version of org.freedesktop.Platform
+        runtimeVersion: "24.08",
         finishArgs: [
             // Wayland/X11 Rendering
             "--socket=wayland",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
         "test": "jest",
         "test:unit": "jest ./src/__tests__/unit",
         "publish": "npm run build && electron-builder -c.win.certificateSha1=206941d969c4fa8a0e04d9427def361e13b02fd0 --config electron-builder.config.js --publish always --win --x64",
-        "publish:linux": "npm run build && electron-builder --config electron-builder.config.js --publish never --linux --x64"
+        "publish:linux": "npm run build && electron-builder --config electron-builder.config.js --publish never --linux --x64",
+        "publish:flatpak": "npm run build && env DEBUG='@malept/flatpak-bundler' npx electron-builder --config electron-builder.config.js --publish never --linux flatpak"
     },
     "lint-staged": {
         "*.{js,jsx,ts,tsx}": [


### PR DESCRIPTION
<!--

Please use the content below as a template for your pull request.
Feel free to remove sections which do not make sense.

-->

## Scope

electron-builder [defaults to 20.08](https://www.electron.build/flatpak.html#baseversion) version of flatpak runtime and base packages. Those packages are EOL, here is example message from flatpak cli:
```
Info: runtime org.freedesktop.Platform branch 20.08 is end-of-life, with reason:
   org.freedesktop.Platform 20.08 is no longer receiving fixes and security updates. Please update to a supported runtime version.
```
I couldn't really find a source of truth for those messages, I suspect it just part of flatpak repository that can report if package is EOL

## Implementation

Manually specify versions for both runtime and base package. This will require to manually bump them later on, but it's just 2 lines of code change approximately every 2 years, so I hope that's not an issue =)

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

Try building flatpak package on a linux distro with `npm run publish:flatpak`

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
