### PR TITLE
[hotfix] fix issue where installed mods are not reflected in mods tab

### DIFF
--- a/src/renderer/components/version-viewer/slides/mods/mods-slide.component.tsx
+++ b/src/renderer/components/version-viewer/slides/mods/mods-slide.component.tsx
@@ -112,9 +112,10 @@ export function ModsSlide({ version, onDisclamerDecline }: { version: BSVersion;
             const defaultMods = installed?.length ? [] : available.filter(m => m.mod.category === BbmCategories.Core || m.mod.category === BbmCategories.Essential);
             setModsAvailable(modsToCategoryMap(available));
             const installedMods: BbmFullMod[] = installed.map(version => {
-                const mod = available.find(m => m.mod.id === version.modId);
-                return mod ? { ...mod, version } : null;
-            });
+                    const mod = available.find(m => m.mod.id === version.modId);
+                    return mod ? { ...mod, version } : null;
+                }).filter(mod => mod);
+
             setModsSelected(available.filter(m => m.mod.category === BbmCategories.Core || defaultMods.some(d => m.mod.name.toLowerCase() === d.mod.name.toLowerCase()) || installedMods.some(i => m.mod.id === i.mod.id)));
             setModsInstalled(modsToCategoryMap(installedMods));
         }).catch(e => {


### PR DESCRIPTION
Fixed an issue in the frontend where installedMods can contain a null element. Just removed the elements from the array.