### PR TITLE
[bugfix] allow compat folder create permission for linux flatpak

### DIFF
--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -69,6 +69,8 @@ const config = {
             "--filesystem=~/.steam/steam/steamapps:ro", // for the libraryfolders.vdf
             "--filesystem=~/.steam/steam/steamapps/common:create", // Steam game folder
             "--filesystem=~/.steam/steam/steamapps/common/Beat Saber:create", // For installing mods/maps to original Beat Saber version
+            // Allow BSManager to create the compat folder if it does not exist
+            "--filesystem=~/.steam/steam/steamapps/compatdata/620980:create",
             // Allow communication with network
             "--share=network",
             // System notifications with libnotify


### PR DESCRIPTION
Bug fix regarding to issue encountered in [discord](https://discord.com/channels/1049624409276694588/1325265216681803937)

## How to Test
Check if reinstalling the flatpak should add the `~/.steam/steam/steamapps/compatdata/620980:create` permission.