### PR TITLE
[bugfix-733] custom compatdata folder for specific BSManager usage

### DIFF
--- a/src/main/services/mods/bs-mods-manager.service.ts
+++ b/src/main/services/mods/bs-mods-manager.service.ts
@@ -151,12 +151,11 @@ export class BsModsManagerService {
             }
             winePath = `"${winePathResult}"`;
 
-            const { error: winePrefixError, result: winePrefixResult } =
-                await tryit(async () => this.linuxService.getWinePrefixPath());
-            if (winePrefixError) {
-                log.warn("Could not get WINEPREFIX value", winePrefixError);
+            const winePrefix = this.linuxService.getWinePrefixPath();
+            if (winePrefix) {
+                env.WINEPREFIX = winePrefix;
             } else {
-                env.WINEPREFIX = winePrefixResult;
+                log.warn("Could not find BSManager WINEPREFIX path, using system's default value instead");
             }
         }
 


### PR DESCRIPTION
Link #733 

The compatdata folder can exist outside of the steam `compatdata` folder. 

In theory of this as well, BS versions can have their on specific configs that doesn't affect every BS version, such as the UserData folder. However the space consumption can increase since the compatdata folder contains the windows OS files/directories.

Notes: you can also launch the game without downloading the steam version of the game, only for linux. Not sure if this can be done on Windows.