### PR TITLE
package.json: correct license value based on ./LICENSE

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
         "url": "https://github.com/Zagrios"
     },
     "contributors": [],
-    "license": "MIT",
+    "license": "GPL-3.0-only",
     "bugs": {
         "url": "https://github.com/Zagrios/bs-manager/issues"
     },


### PR DESCRIPTION
## Scope

Make `LICENSE` and `package.json` consistent.

## Implementation

Set correct value in `package.json`.

## Screenshots

N/A

## How to Test

N/A

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
