### PR TITLE
[feat] added logs when deleting files/folders

### DIFF
--- a/src/__tests__/unit/fs.helpers.test.ts
+++ b/src/__tests__/unit/fs.helpers.test.ts
@@ -2,6 +2,15 @@ import { mkdir, pathExistsSync, rm, writeFile } from "fs-extra";
 import { getSize } from "main/helpers/fs.helpers";
 import path from "path";
 
+jest.mock("electron", () => ({ app: {
+    getPath: () => "",
+    getName: () => "",
+}}));
+jest.mock("electron-log", () => ({
+    info: jest.fn(),
+    error: jest.fn(),
+}));
+
 const TEST_FOLDER = path.resolve(__dirname, "..", "assets", "fs");
 
 describe("Test fs.helpers getSize", () => {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -23,9 +23,11 @@ import { LivShortcut } from "./services/liv/liv-shortcut.service";
 import { SteamLauncherService } from "./services/bs-launcher/steam-launcher.service";
 import { FileAssociationService } from "./services/file-association.service";
 import { SongDetailsCacheService } from "./services/additional-content/maps/song-details-cache.service";
-import { Dirent, readdirSync, rmSync, unlinkSync } from "fs-extra";
+import { Dirent, readdirSync } from "fs-extra";
 import { StaticConfigurationService } from "./services/static-configuration.service";
 import { configureProxy } from './helpers/proxy.helpers';
+import { deleteFileSync, deleteFolderSync } from "./helpers/fs.helpers";
+import { tryit } from "shared/helpers/error.helpers";
 
 const isDebug = process.env.NODE_ENV === "development" || process.env.DEBUG_PROD === "true";
 const staticConfig = StaticConfigurationService.getInstance();
@@ -238,12 +240,7 @@ function deleteOldLogs(): void {
 
     for (const folder of deleteLogFolders) {
         const folderPath = path.join(folder.parentPath, folder.name);
-        try {
-            rmSync(folderPath, { recursive: true, force: true });
-            log.info("Deleted log folder:", folderPath);
-        } catch (error) {
-            log.error("Error deleting folder:", folderPath, error);
-        }
+        tryit(() => deleteFolderSync(folderPath));
     }
 }
 
@@ -255,12 +252,7 @@ function deleteOldestLogs(): void {
 
     for (const file of logs) {
         const filepath = path.join(file.parentPath, file.name);
-        try {
-            unlinkSync(filepath);
-            log.info("Deleted log file:", filepath);
-        } catch (error) {
-            log.error("Error deleting file:", filepath, error);
-        }
+        tryit(() => deleteFileSync(filepath));
     }
 }
 

--- a/src/main/services/additional-content/local-models-manager.service.ts
+++ b/src/main/services/additional-content/local-models-manager.service.ts
@@ -8,7 +8,7 @@ import path from "path";
 import { RequestService } from "../request.service";
 import { copyFileSync } from "fs-extra";
 import sanitize from "sanitize-filename";
-import { Progression, ensureFolderExist, unlinkPath } from "../../helpers/fs.helpers";
+import { Progression, deleteFile, ensureFolderExist } from "../../helpers/fs.helpers";
 import { MODEL_FILE_EXTENSIONS, MODEL_TYPES, MODEL_TYPE_FOLDERS } from "../../../shared/models/models/constants";
 import { InstallationLocationService } from "../installation-location.service";
 import { Observable, Subscription, lastValueFrom } from "rxjs";
@@ -105,7 +105,9 @@ export class LocalModelsManagerService {
     }
 
     public async oneClickDownloadModel(model: MSModel): Promise<void> {
-        if (!model) { return; }
+        if (!model) {
+            return;
+        }
 
         const versions = await this.localVersion.getInstalledVersions();
         const downloaded = await lastValueFrom(this.downloadModel(model, versions.pop()));
@@ -198,7 +200,7 @@ export class LocalModelsManagerService {
                 };
 
                 for (const model of models) {
-                    await unlinkPath(model.path);
+                    await deleteFile(model.path);
                     progression.data.push(model);
                     progression.current = progression.data.length;
                     subscriber.next(progression);

--- a/src/main/services/additional-content/local-playlists-manager.service.ts
+++ b/src/main/services/additional-content/local-playlists-manager.service.ts
@@ -11,7 +11,7 @@ import { BPList, DownloadPlaylistProgressionData, PlaylistSong } from "shared/mo
 import { readFileSync, Stats } from "fs";
 import { BeatSaverService } from "../thrid-party/beat-saver/beat-saver.service";
 import { copy, ensureDir, pathExists, pathExistsSync, realpath, writeFileSync } from "fs-extra";
-import { Progression, getUniqueFileNamePath, unlinkPath } from "../../helpers/fs.helpers";
+import { Progression, deleteFile, getUniqueFileNamePath } from "../../helpers/fs.helpers";
 import { FileAssociationService } from "../file-association.service";
 import { SongDetailsCacheService } from "./maps/song-details-cache.service";
 import { sToMs } from "shared/helpers/time.helpers";
@@ -409,7 +409,7 @@ export class LocalPlaylistsManagerService {
     }
 
     public deletePlaylistFile(bpList: LocalBPList): Observable<void>{
-        return from(unlinkPath(bpList.path));
+        return from(deleteFile(bpList.path));
     }
 
     public exportPlaylists(opt: {version?: BSVersion, bpLists: LocalBPList[], dest: string, playlistsMaps?: BsmLocalMap[]}): Observable<Progression<string>> {

--- a/src/main/services/additional-content/maps/local-maps-manager.service.ts
+++ b/src/main/services/additional-content/maps/local-maps-manager.service.ts
@@ -7,7 +7,7 @@ import { InstallationLocationService } from "../../installation-location.service
 import { UtilsService } from "../../utils.service";
 import crypto, { BinaryLike } from "crypto";
 import { lstatSync } from "fs";
-import { copy, createReadStream, ensureDir, pathExists, pathExistsSync, realpath, unlink } from "fs-extra";
+import { copy, createReadStream, ensureDir, pathExists, pathExistsSync, realpath } from "fs-extra";
 import { RequestService } from "../../request.service";
 import sanitize from "sanitize-filename";
 import { DeepLinkService } from "../../deep-link.service";
@@ -15,7 +15,7 @@ import log from "electron-log";
 import { WindowManagerService } from "../../window-manager.service";
 import { Observable, Subject, lastValueFrom } from "rxjs";
 import { Archive } from "../../../models/archive.class";
-import { Progression, deleteFolder, ensureFolderExist, getFilesInFolder, getFoldersInFolder, pathExist } from "../../../helpers/fs.helpers";
+import { Progression, deleteFile, deleteFolder, ensureFolderExist, getFilesInFolder, getFoldersInFolder, pathExist } from "../../../helpers/fs.helpers";
 import { readFile } from "fs/promises";
 import { FolderLinkerService } from "../../folder-linker.service";
 import { allSettled } from "../../../../shared/helpers/promise.helpers";
@@ -297,7 +297,7 @@ export class LocalMapsManagerService {
                     observer.next(progress);
                 }
             })()
-            .catch(e => {observer.error(e); console.log("AAAA", e)})
+            .catch(e => observer.error(e))
             .finally(() => observer.complete());
         });
     }
@@ -449,7 +449,7 @@ export class LocalMapsManagerService {
         const zip = await BsmZipExtractor.fromPath(zipPath);
         await zip.extract(mapPath);
         zip.close();
-        await unlink(zipPath);
+        await deleteFile(zipPath);
 
         const localMap = await this.loadMapInfoFromPath(mapPath);
         localMap.songDetails = this.songDetailsCache.getSongDetails(localMap.hash);

--- a/src/main/services/folder-linker.service.ts
+++ b/src/main/services/folder-linker.service.ts
@@ -1,9 +1,9 @@
 import { InstallationLocationService } from "./installation-location.service";
 import log from "electron-log";
-import { deleteFolder, ensureFolderExist, moveFolderContent, pathExist, unlinkPath } from "../helpers/fs.helpers";
+import { deleteFile, deleteFileSync, deleteFolder, deleteFolderSync, ensureFolderExist, moveFolderContent, pathExist } from "../helpers/fs.helpers";
 import { lstat, symlink } from "fs/promises";
 import path from "path";
-import { copy, mkdirSync, readlink, rmSync, symlinkSync, unlinkSync } from "fs-extra";
+import { copy, mkdirSync, readlink, symlinkSync } from "fs-extra";
 import { lastValueFrom } from "rxjs";
 import { noop } from "shared/helpers/function.helpers";
 import { StaticConfigurationService } from "./static-configuration.service";
@@ -56,8 +56,8 @@ export class FolderLinkerService {
         });
 
         tryit(() => {
-            rmSync(testFolder, { force: true, recursive: true });
-            unlinkSync(testLink);
+            deleteFolderSync(testFolder);
+            deleteFileSync(testLink);
         });
 
         if(resLink.error){
@@ -113,7 +113,7 @@ export class FolderLinkerService {
             if (isTargetedToSharedPath) {
                 return;
             }
-            await unlinkPath(folderPath);
+            await deleteFile(folderPath);
 
             log.info(`Linking ${folderPath} to ${sharedPath}; type: ${this.linkingType}`);
             return symlink(sharedPath, folderPath, this.getLinkingType());
@@ -141,7 +141,7 @@ export class FolderLinkerService {
         if (!(await this.isFolderSymlink(folderPath))) {
             return;
         }
-        await unlinkPath(folderPath);
+        await deleteFile(folderPath);
 
         const sharedPath = await this.getSharedFolder(folderPath, options?.intermediateFolder);
 

--- a/src/main/services/request.service.ts
+++ b/src/main/services/request.service.ts
@@ -1,11 +1,10 @@
 import { createWriteStream, WriteStream } from 'fs';
-import { Progression } from 'main/helpers/fs.helpers';
+import { deleteFileSync, Progression } from 'main/helpers/fs.helpers';
 import { Observable } from 'rxjs';
 import { shareReplay, tap } from 'rxjs/operators';
 import log from 'electron-log';
 import got from 'got';
 import { IncomingHttpHeaders, IncomingMessage } from 'http';
-import { unlinkSync } from 'fs-extra';
 import { tryit } from 'shared/helpers/error.helpers';
 import path from 'path';
 import { pipeline } from 'stream/promises';
@@ -84,7 +83,7 @@ export class RequestService {
 
                     pipeline(stream, file).catch(err => {
                         file?.destroy();
-                        tryit(() => unlinkSync(dest));
+                        tryit(() => deleteFileSync(dest));
                         subscriber.error(err);
                     });
                 });


### PR DESCRIPTION
Issue from [discord](https://discord.com/channels/1049624409276694588/1334721659696971896)

When deleting a file or folder, log them so that it could be tracked in the logs file when checking for user errors.

Instead of using the direct function in fs, use there equivalent in fs.helpers module implementation.
unlink => deleteFile
unlinkSync => deleteFileSync
rm => deleteFolder
rmSync => deleteFolderSync

NOTE:
The wrapper function contains error codes without any resource, but they don't report anything on the frontend yet so didn't add it for now.