### PR TITLE
[feat] Add build_start script for easier testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "main": "./.erb/dll/main.bundle.dev.js",
     "version": "1.5.2",
     "scripts": {
+        "build_start": "npm run build && npm run start",
         "build-rust-scripts": "ts-node ./.erb/scripts/build-rust-scripts.js",
         "build": "concurrently \"npm run build:main\" \"npm run build:renderer\"",
         "build:dll": "cross-env NODE_ENV=development webpack --config ./.erb/configs/webpack.config.renderer.dev.dll.ts",


### PR DESCRIPTION
## Scope

It's just easier to test when rebuilding is needed to have one command for build and start. It literally just calls build and start one after the other. Often a rebuild isn't needed when making changes, but when it is, having the one command to quickly build and start can be nice.

## Implementation

Just adding `"build_start": "npm run build && npm run start",` to `scripts` in `package.json`

## How to Test

- Run `npm run build_start`
- Wait for bs-manager to build and start