### PR TITLE
Feature/language UI update

### DIFF
--- a/src/renderer/components/settings/setting-radio-array.component.tsx
+++ b/src/renderer/components/settings/setting-radio-array.component.tsx
@@ -8,30 +8,32 @@ type Props<T> = {
     selectedItemId?: number;
     selectedItemValue?: T;
     direction?: CSSProperties["flexDirection"],
+    columnCount?: number;
     onItemSelected?: (item: RadioItem<T>) => void
 };
 
-export function SettingRadioArray<T>({ id, items, selectedItemId, selectedItemValue, onItemSelected, direction = "column" }: Props<T>) {
+export function SettingRadioArray<T>({ id, items, selectedItemId, selectedItemValue, onItemSelected, direction = "column",columnCount = 1, }: Props<T>) {
     const t = useTranslation();
 
     const isSelected = (item: RadioItem<T>) => {
         return item.id === selectedItemId || item.value === selectedItemValue;
     }
 
+
     return (
-        <div id={id} className="w-full flex gap-1.5" style={{flexDirection: direction}}>
+        <div id={id} className={`w-full grid grid-cols-${columnCount} gap-1.5`} style={{flexDirection: direction}}>
             {items.map(i => (
-                <div onClick={() => onItemSelected(i)} key={i.id} className={`py-3 w-full flex cursor-pointer justify-between items-center rounded-md px-2 transition-colors duration-300 ${isSelected(i) ? "bg-light-main-color-3 dark:bg-main-color-3" : "bg-light-main-color-1 dark:bg-main-color-1"} ${i.className}`}>
+                <div onClick={() => onItemSelected(i)} key={i.id} className={`h-12 py-3 w-full flex cursor-pointer justify-between rounded-md px-2 transition-colors duration-300 ${isSelected(i) ? "bg-light-main-color-3 dark:bg-main-color-3" : "bg-light-main-color-1 dark:bg-main-color-1"} ${i.className}`}>
                     <div className="flex items-center">
-                        <div className="h-5 rounded-full aspect-square border-2 border-gray-800 dark:border-white p-[3px] mr-2">
+                        <div className="h-5 rounded-full aspect-square border-2 border-gray-800 dark:border-white p-[3px] mr-2 ">
                             <motion.span initial={{ scale: 0 }} animate={{ scale: isSelected(i) ? 1 : 0 }} className="h-full w-full block bg-gray-800 dark:bg-white rounded-full" />
                         </div>
-                        <h2 className="font-extrabold">{t(i.text)}</h2>
+                        <h2 className="font-extrabold text-nowrap">{t(i.text)}</h2>
                     </div>
                     {i.icon && (
-                        <div className="flex items-center">
+                        <div className="flex items-center text-right">
                             {i.textIcon && <span className="text-sm">{t(i.textIcon)}</span>}
-                            {i.icon}
+                            <span>{i.icon}</span>
                         </div>
                     )}
                 </div>

--- a/src/renderer/components/settings/setting-radio-array.component.tsx
+++ b/src/renderer/components/settings/setting-radio-array.component.tsx
@@ -20,7 +20,7 @@ export function SettingRadioArray<T>({ id, items, selectedItemId, selectedItemVa
     }
 
     return (
-        <div id={id} className={`w-full grid grid-cols-${columnCount} gap-1.5`} style={{flexDirection: direction}}>
+        <div id={id} className="w-full grid gap-1.5" style={{flexDirection: direction, gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))`}}>
             {items.map(i => (
                 <div onClick={() => onItemSelected(i)} key={i.id} className={`h-12 py-3 w-full flex cursor-pointer justify-between rounded-md px-2 transition-colors duration-300 ${isSelected(i) ? "bg-light-main-color-3 dark:bg-main-color-3" : "bg-light-main-color-1 dark:bg-main-color-1"} ${i.className}`}>
                     <div className="flex items-center">

--- a/src/renderer/components/settings/setting-radio-array.component.tsx
+++ b/src/renderer/components/settings/setting-radio-array.component.tsx
@@ -19,13 +19,12 @@ export function SettingRadioArray<T>({ id, items, selectedItemId, selectedItemVa
         return item.id === selectedItemId || item.value === selectedItemValue;
     }
 
-
     return (
         <div id={id} className={`w-full grid grid-cols-${columnCount} gap-1.5`} style={{flexDirection: direction}}>
             {items.map(i => (
                 <div onClick={() => onItemSelected(i)} key={i.id} className={`h-12 py-3 w-full flex cursor-pointer justify-between rounded-md px-2 transition-colors duration-300 ${isSelected(i) ? "bg-light-main-color-3 dark:bg-main-color-3" : "bg-light-main-color-1 dark:bg-main-color-1"} ${i.className}`}>
                     <div className="flex items-center">
-                        <div className="h-5 rounded-full aspect-square border-2 border-gray-800 dark:border-white p-[3px] mr-2 ">
+                        <div className="h-5 rounded-full aspect-square border-2 border-gray-800 dark:border-white p-[3px] mr-2">
                             <motion.span initial={{ scale: 0 }} animate={{ scale: isSelected(i) ? 1 : 0 }} className="h-full w-full block bg-gray-800 dark:bg-white rounded-full" />
                         </div>
                         <h2 className="font-extrabold text-nowrap">{t(i.text)}</h2>

--- a/src/renderer/components/settings/setting-radio-array.component.tsx
+++ b/src/renderer/components/settings/setting-radio-array.component.tsx
@@ -32,7 +32,7 @@ export function SettingRadioArray<T>({ id, items, selectedItemId, selectedItemVa
                     {i.icon && (
                         <div className="flex items-center text-right">
                             {i.textIcon && <span className="text-sm">{t(i.textIcon)}</span>}
-                            <span>{i.icon}</span>
+                            {i.icon}
                         </div>
                     )}
                 </div>

--- a/src/renderer/pages/settings-page.component.tsx
+++ b/src/renderer/pages/settings-page.component.tsx
@@ -496,7 +496,7 @@ export function SettingsPage() {
                 </SettingContainer>
 
                 <SettingContainer title="pages.settings.language.title" description="pages.settings.language.description">
-                    <SettingRadioArray items={languagesItems} selectedItemValue={languageSelected} onItemSelected={handleChangeLanguage} />
+                    <SettingRadioArray items={languagesItems} selectedItemValue={languageSelected} onItemSelected={handleChangeLanguage} columnCount={2} />
                 </SettingContainer>
 
                 <SettingContainer title="pages.settings.patreon.title" description="pages.settings.patreon.description">


### PR DESCRIPTION
## Implementation
With the number of languages supported by BSM increasing all the time, a small redesign of the display to divide everything into two columns makes it all look better :D 

## Screenshots

| before | after |
| ------ | ----- |
|![image](https://github.com/user-attachments/assets/35d514c6-e0d2-4956-b898-a04614c9eb89)|![image](https://github.com/user-attachments/assets/2ab99be7-a916-4ba6-b831-ee2c39a21db9)![image](https://github.com/user-attachments/assets/f9b48f10-35a6-40df-bfa5-ca4764037102)|

## How to Test
- Clone my branch
- use `npm i` then `npm start`
- go settings

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
