### PR TITLE
add missing translation in chinese (simplified)

### DIFF
--- a/assets/jsons/translations/zh.json
+++ b/assets/jsons/translations/zh.json
@@ -240,6 +240,7 @@
                     "es-ES": "Español",
                     "it-IT": "Italiano",
                     "de-DE": "Deutsch",
+                    "pt-BR": "Português (Brasil)",
                     "ru-RU": "Русский",
                     "zh-CN": "简体中文",
                     "zh-TW": "正體中文",


### PR DESCRIPTION
## Scope

[closes TICKET-798](https://github.com/Zagrios/bs-manager/issues/798)

## Implementation

Fix missing translation for the name of portguese (brazil) with chinese (simplified) language.

## Screenshots

| before | after |
| ------ | ----- |
|![image](https://github.com/user-attachments/assets/5bd5549c-7b55-45b3-ad9b-758fc49f7df3)|![image](https://github.com/user-attachments/assets/8659461d-8b42-448c-96a0-286e198a9bed)|

## How to Test

- go to settings
- Select Chinese (simplified)
- check brazil

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
