### PR TITLE
[bugfix] fix issue with extracting root map files

### DIFF
--- a/src/main/services/additional-content/maps/local-maps-manager.service.ts
+++ b/src/main/services/additional-content/maps/local-maps-manager.service.ts
@@ -369,10 +369,12 @@ export class LocalMapsManagerService {
                     for (const folder of mapsFolders) {
                         log.info(">", folder);
 
-                        const regex = new RegExp(`^${escapeRegExp(folder)}\\/`);
+                        const entriesNames = isRoot
+                            ? null
+                            : [ new RegExp(`^${escapeRegExp(folder)}\\/`) ];
 
                         const exported = await zip.extract(destination, {
-                            entriesNames: [regex],
+                            entriesNames,
                             abortToken: abortController
                         });
 


### PR DESCRIPTION
The regex for root map folders was broken, just extract the full zip instead.