### PR TITLE
[chore] update GlowEffect visibility logic in LaunchSlide component

### DIFF
--- a/src/renderer/components/version-viewer/slides/launch/launch-slide.component.tsx
+++ b/src/renderer/components/version-viewer/slides/launch/launch-slide.component.tsx
@@ -14,7 +14,6 @@ import { lastValueFrom } from "rxjs";
 import { BsDownloaderService } from "renderer/services/bs-version-download/bs-downloader.service";
 import equal from "fast-deep-equal";
 import { GlowEffect } from "renderer/components/shared/glow-effect.component";
-import { cn } from "renderer/helpers/css-class.helpers";
 import { BSVersionManagerService } from "renderer/services/bs-version-manager.service";
 import { safeLt } from "shared/helpers/semver.helpers";
 import { WarningIcon } from "renderer/components/svgs/icons/warning-icon.component";
@@ -193,9 +192,9 @@ export function LaunchSlide({ version }: Props) {
             </div>
             <div className="mt-4 flex flex-col items-center justify-center gap-3">
                 <div className="relative">
-                    <GlowEffect className="!rounded-full" visible={!!(activeLaunchMods?.length || command)}/>
+                    <GlowEffect className="!rounded-full" visible={!!((activeLaunchMods?.filter(mod => !pinnedLaunchMods.includes(mod)))?.length || command)}/>
                     <BsmButton
-                        className={cn("rounded-full w-fit text-lg py-1 px-7 bg-theme-2 text-gray-800 dark:text-white", (advancedLaunch && command) ? "" : "shadow-md shadow-black")}
+                        className="rounded-full w-fit text-lg py-1 px-7 bg-theme-2 text-gray-800 dark:text-white shadow-md shadow-black"
                         text="pages.version-viewer.launch-mods.advanced-launch.button"
                         withBar={false}
                         onClick={e => {


### PR DESCRIPTION
`Launch options` button now only glow when unpinned options are enabled or if a command is present
![image](https://github.com/user-attachments/assets/f9850754-f2a0-4df8-8a76-7ce8e3896cb5)
![image](https://github.com/user-attachments/assets/a987748b-f3f4-4fe2-b081-cf1db36e7ec0)
