### PR TITLE
[bugfix] allow env overriding with launch options

### DIFF
--- a/src/main/services/bs-launcher/abstract-launcher.service.ts
+++ b/src/main/services/bs-launcher/abstract-launcher.service.ts
@@ -137,12 +137,11 @@ export abstract class AbstractLauncherService {
         const envString = command.substring(0, index);
         log.info("Parsing env string ", `"${envString}"`)
         for (const [ key, value ] of Object.entries(parseEnvString(envString))) {
-            if (key in env) {
-                log.warn("Ignoring", `${key}=${value}`, "already set env launch command");
-                continue;
-            }
-
-            log.info("Injecting", `${key}="${value}"`, "to the env launch command");
+            log.info(
+                key in env ? "Overriding" : "Injecting",
+                `${key}="${value}"`,
+                "to the env launch command"
+            );
             env[key] = value;
         }
 


### PR DESCRIPTION
Allow env vars to be overridden instead of being ignored, so that ie. Flatpak users can fix some invalid setting for the ENV_VARS like XAuthority

ref: [Discord](https://discord.com/channels/1049624409276694588/1329541144836571197)