### PR TITLE
[bugfix] Fix mod installation on NixOS

### DIFF
--- a/src/main/services/linux.service.ts
+++ b/src/main/services/linux.service.ts
@@ -129,12 +129,7 @@ export class LinuxService {
         return fs.pathExistsSync(protonPath) && fs.pathExistsSync(winePath);
     }
 
-    public async getWinePath(): Promise<string> {
-        if (await this.isNixOS()) {
-            // Use system wine for nixos
-            return "wine";
-        }
-
+    public getWinePath(): string {
         if (!this.staticConfig.has("proton-folder")) {
             throw new Error("proton-folder variable not set");
         }

--- a/src/main/services/mods/bs-mods-manager.service.ts
+++ b/src/main/services/mods/bs-mods-manager.service.ts
@@ -162,12 +162,15 @@ export class BsModsManagerService {
         let winePath: string = "";
         if (process.platform === "linux") {
             const { error: winePathError, result: winePathResult } =
-                await tryit(async () => this.linuxService.getWinePath());
+                tryit(() => this.linuxService.getWinePath());
             if (winePathError) {
                 log.error(winePathError);
                 return false;
             }
-            winePath = `"${winePathResult}"`;
+
+            winePath = await this.linuxService.isNixOS()
+                ? `steam-run "${winePathResult}"`
+                : `"${winePathResult}"`;
 
             const winePrefix = this.linuxService.getWinePrefixPath();
             if (!winePrefix) {

--- a/src/main/services/mods/bs-mods-manager.service.ts
+++ b/src/main/services/mods/bs-mods-manager.service.ts
@@ -174,6 +174,7 @@ export class BsModsManagerService {
                 throw new CustomError("Could not find BSManager WINEPREFIX path", "no-wineprefix");
             }
             env.WINEPREFIX = winePrefix;
+            Object.assign(env, process.env);
         }
 
         return new Promise<boolean>(resolve => {


### PR DESCRIPTION
<!--

Please use the content below as a template for your pull request.
Feel free to remove sections which do not make sense.

-->

## Scope

<!-- Brief description of WHAT you’re doing and WHY. -->
Inherits environment when starting wine for BSIPA installation, which matches behaviour when launching Beat Saber.
Use selected Proton's wine instead of system wine, since the wine prefix version may mismatch and cause wine to crash.

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
