### PR TITLE
[bugfix-865] unref process to close window - create BSMHook

### DIFF
--- a/assets/jsons/translations/en.json
+++ b/assets/jsons/translations/en.json
@@ -64,6 +64,8 @@
                 },
                 "skipsteam": "Skip Steam",
                 "skipsteam-description": "Stops Steam from opening automatically with Beat Saber, enable if you are using a different VR runtime like WiVRn or Monado that SteamVR may interfere with.",
+                "bsm-hook": "BSMHook",
+                "bsm-hook-description": "Install and use the BSMHook mod. Enable this if you are having problems with SteamVR opening while starting in FPFC. This works only in modded instances",
                 "map-editor": "Map Editor",
                 "map-editor-description": "Start the official Beat Saber map editor instead of the game.",
                 "proton-logs": "Proton Logs",

--- a/src/main/ipcs/bs-mods-ipcs.ts
+++ b/src/main/ipcs/bs-mods-ipcs.ts
@@ -15,6 +15,11 @@ ipc.on("bs-mods.get-installed-mods", (args, reply) => {
     reply(from(modsManager.getInstalledMods(args)));
 });
 
+ipc.on("bs-mods.is-modded", (args, reply) => {
+    const modsManager = BsModsManagerService.getInstance();
+    reply(from(modsManager.isModded(args)));
+});
+
 ipc.on("bs-mods.import-mods", (args, reply) => {
     const modsManager = BsModsManagerService.getInstance();
     reply(modsManager.importMods(args.paths, args.version));
@@ -38,4 +43,5 @@ ipc.on("bs-mods.uninstall-all-mods", (args, reply) => {
 ipc.on("bs-mods.beatmods-up", (_, reply) => {
     const beatMods = BeatModsApiService.getInstance();
     reply(from(beatMods.isUp()));
-})
+});
+

--- a/src/main/services/bs-launcher/bsm-hook.service.ts
+++ b/src/main/services/bs-launcher/bsm-hook.service.ts
@@ -1,0 +1,58 @@
+import log from "electron-log";
+import { createServer, Server, Socket } from "net";
+
+export class BSMHookService {
+    private static instance: BSMHookService;
+    private server: Server;
+    private onData?: (data: Buffer) => void;
+    private onError?: (err: Error) => void;
+    private sockets: Set<Socket> = new Set();
+
+    public static getInstance(): BSMHookService {
+        if (!BSMHookService.instance) {
+            BSMHookService.instance = new BSMHookService();
+        }
+        return BSMHookService.instance;
+    }
+
+    private constructor() {
+        this.server = createServer(socket => {
+            this.sockets.add(socket);
+
+            socket.on("data", data => {
+                log.info(`Received BSMHook data: ${data}`);
+                this.onData?.(data);
+            });
+
+            socket.on("error", err => {
+                log.error(`Socket error: ${err.message}`);
+                this.onError?.(err);
+                this.server?.close();
+            });
+
+            socket.on("close", () => {
+                log.info("BSMHook socket closed");
+                this.onData = undefined;
+                this.onError = undefined;
+            });
+        });
+    }
+
+    public start(onData?: (data: Buffer) => void, onError?: (err: Error) => void) {
+        this.onData = onData;
+        this.onError = onError;
+        this.server.listen(58127, "127.0.0.1", () => {
+            log.info("BSMHook socket server listening on 127.0.0.1:58127");
+        });
+    }
+
+    public close() {
+        this.server.close();
+        this.server.removeAllListeners();
+
+        this.sockets.forEach(socket => {
+            socket.write('bye');
+        });
+        this.sockets.clear();
+    }
+}

--- a/src/main/services/mods/bs-mods-manager.service.ts
+++ b/src/main/services/mods/bs-mods-manager.service.ts
@@ -398,6 +398,10 @@ export class BsModsManagerService {
         return Array.from(modsDict.values());
     }
 
+    public async isModded(version: BSVersion): Promise<boolean> {
+        return Boolean(await this.getBsipaInstalled(version));
+    }
+
     private async importMod(modPath: string, destination: string): Promise<string[]> {
         const extensionName = path.extname(modPath).toLowerCase();
 

--- a/src/renderer/components/version-viewer/slides/launch/launch-slide.component.tsx
+++ b/src/renderer/components/version-viewer/slides/launch/launch-slide.component.tsx
@@ -27,6 +27,8 @@ import { DefaultConfigKey } from "renderer/config/default-configuration.config";
 import { EditIcon } from "renderer/components/svgs/icons/edit-icon.component";
 import { ModalExitCode, ModalService } from "renderer/services/modale.service";
 import { CreateCustomLaunchOptionModal } from "renderer/components/modal/modal-types/create-custom-launch-option.component";
+import { BsModsManagerService } from "renderer/services/bs-mods-manager.service";
+
 
 type Props = { version: BSVersion };
 
@@ -38,6 +40,7 @@ export function LaunchSlide({ version }: Props) {
     const bsDownloader = useService(BsDownloaderService);
     const versions = useService(BSVersionManagerService);
     const modal = useService(ModalService);
+    const modsManager = useService(BsModsManagerService);
 
     const [advancedLaunch, setAdvancedLaunch] = useState(false);
     const [command, setCommand] = useState<string>(configService.get<string>("launch-command") || "");
@@ -168,6 +171,16 @@ export function LaunchSlide({ version }: Props) {
                 visible: window.electron.platform === "linux",
                 onChange: (checked) => toggleActiveLaunchMod(checked, LaunchMods.PROTON_LOGS),
                 onPinChange: (pinned) => togglePinnedLaunchMod(pinned, LaunchMods.PROTON_LOGS),
+            },
+            {
+                id: LaunchMods.BSM_HOOK,
+                label: t("pages.version-viewer.launch-mods.bsm-hook"),
+                description: t("pages.version-viewer.launch-mods.bsm-hook-description"),
+                active: activeLaunchMods.includes(LaunchMods.BSM_HOOK),
+                pinned: pinnedLaunchMods.includes(LaunchMods.BSM_HOOK),
+                //visible: modsManager.getVersionModsState(version).then((mods) => mods.installed.find((mod) => mod.mod.name.includes("BSIPA") !== undefined), (err) => console.log(err)),
+                onChange: (checked) => toggleActiveLaunchMod(checked, LaunchMods.BSM_HOOK),
+                onPinChange: (pinned) => togglePinnedLaunchMod(pinned, LaunchMods.BSM_HOOK),
             },
             ...customOptions,
         ]

--- a/src/renderer/components/version-viewer/slides/launch/launch-slide.component.tsx
+++ b/src/renderer/components/version-viewer/slides/launch/launch-slide.component.tsx
@@ -49,6 +49,7 @@ export function LaunchSlide({ version }: Props) {
     const versionDownloading = useObservable(() => bsDownloader.downloadingVersion$);
     const [activeLaunchMods, setActiveLaunchMods] = useState<string[]>(configService.get("launch-mods") ?? []);
     const [pinnedLaunchMods, setPinnedLaunchMods] = useState<string[]>(configService.get("pinned-launch-mods" as DefaultConfigKey) ?? []);
+    const [isVersionModded, setIsVersionModded] = useState<boolean>(false);
 
     const versionRunning = useObservable(() => bsLauncherService.versionRunning$);
 
@@ -67,6 +68,28 @@ export function LaunchSlide({ version }: Props) {
             bsLauncherService.restoreSteamVR();
         }
     }, [activeLaunchMods]);
+    //useEffect(() => {
+    //    let isMounted = true;
+//
+    //    async function checkBsipa() {
+    //        try {
+    //            const sub = modsManager.getInstalledMods(version).subscribe((mods) => {
+    //                setIsVersionModded(mods.some((mod) => mod.id === 1));
+    //                sub.unsubscribe();
+    //            });
+    //        } catch (err) {
+    //            setIsVersionModded(false);
+    //        }
+    //    };
+//
+    //    if (isMounted) {
+    //        checkBsipa();
+    //    }
+//
+    //    return () => {
+    //        isMounted = false;
+    //    };
+    //}, [version, modsManager]);
 
     const toggleActiveLaunchMod = (checked: boolean, launchMod: string) => checked
         ? setActiveLaunchMods(prev => [...prev, launchMod])
@@ -178,7 +201,7 @@ export function LaunchSlide({ version }: Props) {
                 description: t("pages.version-viewer.launch-mods.bsm-hook-description"),
                 active: activeLaunchMods.includes(LaunchMods.BSM_HOOK),
                 pinned: pinnedLaunchMods.includes(LaunchMods.BSM_HOOK),
-                //visible: modsManager.getVersionModsState(version).then((mods) => mods.installed.find((mod) => mod.mod.name.includes("BSIPA") !== undefined), (err) => console.log(err)),
+                //visible: isVersionModded,
                 onChange: (checked) => toggleActiveLaunchMod(checked, LaunchMods.BSM_HOOK),
                 onPinChange: (pinned) => togglePinnedLaunchMod(pinned, LaunchMods.BSM_HOOK),
             },

--- a/src/renderer/services/bs-mods-manager.service.ts
+++ b/src/renderer/services/bs-mods-manager.service.ts
@@ -45,6 +45,10 @@ export class BsModsManagerService {
         return this.ipcService.sendV2("bs-mods.get-installed-mods", version);
     }
 
+    public isModded(version: BSVersion): Promise<boolean> {
+        return lastValueFrom(this.ipcService.sendV2("bs-mods.is-modded", version));
+    }
+
     public installMods(mods: BbmFullMod[], version: BSVersion): Observable<Progression> {
 
         if (!this.progressBar.require()) {

--- a/src/shared/models/bs-launch/launch-option.interface.ts
+++ b/src/shared/models/bs-launch/launch-option.interface.ts
@@ -7,6 +7,7 @@ export const LaunchMods = {
     SKIP_STEAM: "skip_steam",
     EDITOR: "editor",
     PROTON_LOGS: "proton_logs",
+    BSM_HOOK: "bsm_hook",
 } as const;
 
 export type LaunchMod = typeof LaunchMods[keyof typeof LaunchMods];

--- a/src/shared/models/ipc/ipc-routes.ts
+++ b/src/shared/models/ipc/ipc-routes.ts
@@ -84,6 +84,7 @@ export interface IpcChannelMapping {
     /* ** bs-mods-ipcs ** */
     "bs-mods.get-available-mods": { request: BSVersion, response: BbmFullMod[] };
     "bs-mods.get-installed-mods": { request: BSVersion, response: BbmModVersion[] };
+    "bs-mods.is-modded": { request: BSVersion, response: boolean },
     "bs-mods.import-mods": { request: { paths: string[]; version: BSVersion; }, response: Progression<ExternalMod> };
     "bs-mods.install-mods": { request: { mods: BbmFullMod[]; version: BSVersion }, response: Progression };
     "bs-mods.uninstall-mods": { request: { mods: BbmFullMod[]; version: BSVersion }, response: Progression };


### PR DESCRIPTION
## Scope

Added BSMHook for checking when the game starts correctly

[closes TICKET-###](https://link-to-your-ticket)

## Implementation

Uses a socket and BSMHook mod to check when the game loads the MainMenu scene before resolving the promise (and closing the launcher in case of launching from shortcut.

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
