### PR TITLE
[fix] use a caching method for ipv4/6 request calls

### DIFF
--- a/src/main/services/mods/beat-mods-api.service.ts
+++ b/src/main/services/mods/beat-mods-api.service.ts
@@ -76,8 +76,7 @@ export class BeatModsApiService {
         }
 
         return this.requestService.getJSON<{ modVersions: BbmModVersion[] }>(
-            `${this.MODS_REPO_API_URL}/hashlookup?hash=${hash}`,
-            { silentError: true }
+            `${this.MODS_REPO_API_URL}/hashlookup?hash=${hash}`
         ).then(({ data }) => {
             this.updateModsHashCache(data?.modVersions ?? []);
             return data?.modVersions?.at(0);

--- a/src/main/services/request.service.ts
+++ b/src/main/services/request.service.ts
@@ -9,10 +9,12 @@ import { tryit } from 'shared/helpers/error.helpers';
 import path from 'path';
 import { pipeline } from 'stream/promises';
 import sanitize from 'sanitize-filename';
+import internal from 'stream';
 import { app } from 'electron';
 
 export class RequestService {
     private static instance: RequestService;
+    private preferredFamily: number | undefined = undefined;
     private readonly baseHeaders = {
         'User-Agent': `BSManager/${app.getVersion()} (Electron/${process.versions.electron} Chrome/${process.versions.chrome} Node/${process.versions.node})`,
     }
@@ -28,20 +30,23 @@ export class RequestService {
 
     private constructor() {}
 
-    public async getJSON<T = unknown>(url: string, options?: {
-        silentError?: boolean
-    }): Promise<{ data: T; headers: IncomingHttpHeaders }> {
+    public async getJSON<T = unknown>(url: string): Promise<{ data: T; headers: IncomingHttpHeaders }> {
+        const familiesToTry = this.preferredFamily ? [this.preferredFamily, this.preferredFamily === 4 ? 6 : 4] : [4, 6];
 
-        try {
-            // @ts-ignore (ESM is not well supported in this project, We need to move out electron-react-boilerplate, and use Vite)
-            const res = await got(url, { responseType: 'json', headers: this.baseHeaders });
-            return { data: res.body as T, headers: res.headers };
-        } catch (err) {
-            if (options?.silentError !== true) {
-                log.error(`Failed to get JSON from URL: ${url}`, err);
+        for (const family of familiesToTry) {
+            try {
+                // @ts-ignore (ESM is not well supported in this project, We need to move out electron-react-boilerplate, and use Vite)
+                const res = await got(url, { dnsLookupIpVersion: family, responseType: 'json', headers: this.baseHeaders });
+                this.preferredFamily = family;
+                return { data: res.body as T, headers: res.headers };
+            } catch (err) {
+                log.warn(`IPv${family} request failed, trying next one... URL: ${url}`, err);
             }
-            throw err;
         }
+
+        log.error(`IPv4 and IPv6 requests failed for URL: ${url}`);
+        this.preferredFamily = undefined;
+        throw new Error(`IPv4 and IPv6 requests failed for URL: ${url}`);
     }
 
     public downloadFile(
@@ -51,47 +56,63 @@ export class RequestService {
     ): Observable<Progression<string>> {
         return new Observable<Progression<string>>((subscriber) => {
             const progress: Progression<string> = { current: 0, total: 0 };
+            const familiesToTry = this.preferredFamily ? [this.preferredFamily, this.preferredFamily === 4 ? 6 : 4] : [4, 6];
 
-            let file: WriteStream | undefined;
+            let attempt = 0;
+            let stream: got.GotEmitter & internal.Duplex;
 
-            // @ts-ignore (ESM is not well supported in this project, We need to move out electron-react-boilerplate, and use Vite)
-            const stream = got.stream(url, { headers: this.baseHeaders });
-
-            stream.on('response', (response) => {
-
-                const filename = opt?.preferContentDisposition ? this.getFilenameFromContentDisposition(response.headers['content-disposition']) : null;
-
-                if (filename) {
-                    dest = path.join(path.dirname(dest), sanitize(filename));
+            const tryNextFamily = () => {
+                if (attempt >= familiesToTry.length) {
+                    subscriber.error(new Error(`Download failed over IPv4 and IPv6 for URL: ${url}`));
+                    return;
                 }
 
-                progress.data = dest;
-                file = createWriteStream(dest);
+                const family = familiesToTry[attempt++];
+                let file: WriteStream | undefined;
 
-                pipeline(stream, file).catch(err => {
-                    file?.destroy();
-                    tryit(() => deleteFileSync(dest));
-                    subscriber.error(err);
+                // @ts-ignore (ESM is not well supported in this project, We need to move out electron-react-boilerplate, and use Vite)
+                stream = got.stream(url, { dnsLookupIpVersion: family, headers: this.baseHeaders });
+
+                stream.on('response', (response) => {
+                    this.preferredFamily = family;
+
+                    const filename = opt?.preferContentDisposition ? this.getFilenameFromContentDisposition(response.headers['content-disposition']) : null;
+
+                    if (filename) {
+                        dest = path.join(path.dirname(dest), sanitize(filename));
+                    }
+
+                    progress.data = dest;
+                    file = createWriteStream(dest);
+
+                    pipeline(stream, file).catch(err => {
+                        file?.destroy();
+                        tryit(() => deleteFileSync(dest));
+                        subscriber.error(err);
+                    });
                 });
-            });
 
-            stream.on('downloadProgress', ({ transferred, total }) => {
-                progress.current = transferred;
-                progress.total = total;
-                subscriber.next(progress);
-            });
+                stream.on('downloadProgress', ({ transferred, total }) => {
+                    progress.current = transferred;
+                    progress.total = total;
+                    subscriber.next(progress);
+                });
 
-            stream.on('error', err => {
-                log.error(`Download failed for URL: ${url}`, err);
-                stream.destroy();
-                file?.destroy();
-            });
+                stream.on('error', err => {
+                    log.warn(`Download failed over IPv${family} for URL: ${url}`, err);
+                    stream.destroy();
+                    file?.destroy();
+                    tryNextFamily();
+                });
 
-            stream.on('end', () => {
-                file?.end();
-                subscriber.next(progress);
-                subscriber.complete();
-            });
+                stream.on('end', () => {
+                    file?.end();
+                    subscriber.next(progress);
+                    subscriber.complete();
+                });
+            };
+
+            tryNextFamily();
 
             return () => {
                 stream?.destroy();
@@ -106,7 +127,6 @@ export class RequestService {
         url: string,
         options?: got.GotOptions<null>
     ): Observable<Progression<Buffer, IncomingMessage>> {
-
         return new Observable<Progression<Buffer, IncomingMessage>>((subscriber) => {
             const progress: Progression<Buffer, IncomingMessage> = {
                 current: 0,
@@ -115,38 +135,54 @@ export class RequestService {
             };
 
             const headers = { ...this.baseHeaders, ...(options?.headers ?? {}) };
+            const familiesToTry = this.preferredFamily ? [this.preferredFamily, this.preferredFamily === 4 ? 6 : 4] : [4, 6];
 
-            // @ts-ignore (ESM is not well supported in this project, We need to move out electron-react-boilerplate, and use Vite)
-            const stream = got.stream(url, { ...(options ?? {}), headers });
+            let attempt = 0;
+            let stream: got.GotEmitter & internal.Duplex;
 
-            let data = Buffer.alloc(0);
-            let response: IncomingMessage;
+            const tryNextFamily = () => {
+                if (attempt >= familiesToTry.length) {
+                    subscriber.error(new Error(`Download failed over IPv4 and IPv6 for URL: ${url}`));
+                    return;
+                }
 
-            stream.once('response', (res) => {
-                response = res;
-            });
+                const family = familiesToTry[attempt++];
+                // @ts-ignore (ESM is not well supported in this project, We need to move out electron-react-boilerplate, and use Vite)
+                stream = got.stream(url, { dnsLookupIpVersion: family, ...(options ?? {}), headers });
 
-            stream.on('data', (chunk: Buffer) => {
-                data = Buffer.concat([data, chunk]);
-            });
+                let data = Buffer.alloc(0);
+                let response: IncomingMessage;
 
-            stream.on('downloadProgress', ({ transferred, total }) => {
-                progress.current = transferred;
-                progress.total = total;
-                subscriber.next(progress);
-            });
+                stream.once('response', (res) => {
+                    this.preferredFamily = family;
+                    response = res;
+                });
 
-            stream.on('error', err => {
-                log.error(`Download failed for URL: ${url}`, err);
-                stream.destroy();
-            });
+                stream.on('data', (chunk: Buffer) => {
+                    data = Buffer.concat([data, chunk]);
+                });
 
-            stream.on('end', () => {
-                progress.data = data;
-                progress.extra = response;
-                subscriber.next(progress);
-                subscriber.complete();
-            });
+                stream.on('downloadProgress', ({ transferred, total }) => {
+                    progress.current = transferred;
+                    progress.total = total;
+                    subscriber.next(progress);
+                });
+
+                stream.on('error', err => {
+                    log.warn(`Download failed over IPv${family} for URL: ${url}`, err);
+                    stream.destroy();
+                    tryNextFamily();
+                });
+
+                stream.on('end', () => {
+                    progress.data = data;
+                    progress.extra = response;
+                    subscriber.next(progress);
+                    subscriber.complete();
+                });
+            };
+
+            tryNextFamily();
 
             return () => {
                 stream?.destroy();

--- a/src/main/services/request.service.ts
+++ b/src/main/services/request.service.ts
@@ -18,7 +18,7 @@ export class RequestService {
         'User-Agent': `BSManager/${app.getVersion()} (Electron/${process.versions.electron} Chrome/${process.versions.chrome} Node/${process.versions.node})`,
     }
 
-    private readonly PREFERRED_FAMILY_TESTS = [6, 4];
+    private readonly PREFERRED_FAMILY_TESTS = [4, 6];
     private preferredFamilyCache: Record<string, number> = {};
 
     public static getInstance(): RequestService {
@@ -99,6 +99,7 @@ export class RequestService {
 
                 stream.on('response', (response) => {
                     if (!cachedFamily) {
+                        log.info(`Caching "${domain}" with IPv${family}`);
                         this.preferredFamilyCache[domain] = family;
                     }
 
@@ -185,6 +186,7 @@ export class RequestService {
 
                 stream.once('response', (res) => {
                     if (!cachedFamily) {
+                        log.info(`Caching "${domain}" with IPv${family}`);
                         this.preferredFamilyCache[domain] = family;
                     }
                     response = res;


### PR DESCRIPTION
~~Somewhat support ipv4, unlike the original implementation was to always check between the 2, let the user either use ipv6 (default) or force ipv4 in the settings.~~

Applied logic from https://github.com/Zagrios/bs-manager/pull/872#issuecomment-2954092281 insteadd