### PR TITLE
[fix] return null if downloadMap will incur an error

### DIFF
--- a/src/main/services/additional-content/maps/local-maps-manager.service.ts
+++ b/src/main/services/additional-content/maps/local-maps-manager.service.ts
@@ -448,18 +448,23 @@ export class LocalMapsManagerService {
             return installedMap;
         }
 
-        const zipPath = await this.downloadMapZip(zipUrl);
-        const zip = await BsmZipExtractor.fromPath(zipPath);
-        await zip.extract(mapPath);
-        zip.close();
-        await deleteFile(zipPath);
+        try {
+            const zipPath = await this.downloadMapZip(zipUrl);
+            const zip = await BsmZipExtractor.fromPath(zipPath)
 
-        const localMap = await this.loadMapInfoFromPath(mapPath);
-        localMap.songDetails = this.songDetailsCache.getSongDetails(localMap.hash);
+            await zip.extract(mapPath);
+            zip.close();
+            await deleteFile(zipPath);
 
-        this._lastDownloadedMap.next({ map: localMap, version });
+            const localMap = await this.loadMapInfoFromPath(mapPath);
+            localMap.songDetails = this.songDetailsCache.getSongDetails(localMap.hash);
 
-        return localMap;
+            this._lastDownloadedMap.next({ map: localMap, version });
+
+            return localMap;
+        } catch (_error: any) {
+            return null;
+        }
     }
 
     public async exportMaps(version: BSVersion, maps: BsmLocalMap[], outPath: string): Promise<Observable<Progression>> {


### PR DESCRIPTION
Issue described in [discord](https://discord.com/channels/1049624409276694588/1372636338913939497)

`downloadMap` throws an error instead of returning a null value, created a try catch wrapper to avoid the issue.