### PR TITLE
[fix/634] fixed issue on hovering on last song element

### DIFF
--- a/src/renderer/components/maps-playlists-panel/maps/local-maps-list-panel.component.tsx
+++ b/src/renderer/components/maps-playlists-panel/maps/local-maps-list-panel.component.tsx
@@ -249,8 +249,8 @@ export const LocalMapsListPanel = forwardRef<unknown, Props>(({
 
     return (
             <VirtualScroll
-                classNames={{ mainDiv: className, rows: "gap-x-2 px-2 py-2" }}
-                itemHeight={116}
+                classNames={{ mainDiv: className, rows: "gap-x-2 px-2 pt-2 pb-[108px]" }}
+                itemHeight={108}
                 maxColumns={3}
                 minItemWidth={400}
                 items={preppedMaps}

--- a/src/renderer/components/maps-playlists-panel/maps/local-maps-list-panel.component.tsx
+++ b/src/renderer/components/maps-playlists-panel/maps/local-maps-list-panel.component.tsx
@@ -250,7 +250,7 @@ export const LocalMapsListPanel = forwardRef<unknown, Props>(({
     return (
             <VirtualScroll
                 classNames={{ mainDiv: className, rows: "gap-x-2 px-2 py-2" }}
-                itemHeight={108}
+                itemHeight={116}
                 maxColumns={3}
                 minItemWidth={400}
                 items={preppedMaps}


### PR DESCRIPTION
Closes #634 
Issue also described in [discord](https://discord.com/channels/1049624409276694588/1373728798410805409)

Adjusted the correct height for the map item so that it could account for the padding y correctly.

EDIT: Although the gap spacing might not be to your liking, do we need to adjust it to something smaller?

![image](https://github.com/user-attachments/assets/93f32397-05d4-4055-9405-7a0d843a7cd3)
