### PR TITLE
Beatmods api update

### DIFF
--- a/src/main/services/mods/beat-mods-api.service.ts
+++ b/src/main/services/mods/beat-mods-api.service.ts
@@ -38,6 +38,7 @@ export class BeatModsApiService {
     }
 
     private getVersionModsUrl(version: BSVersion): string {
+        // TODO: This endpoint is now deprecated
         const platform: BbmPlatform = version.oculus || version.metadata?.store === BsStore.OCULUS ? BbmPlatform.OculusPC : BbmPlatform.SteamPC;
         return `${this.MODS_REPO_API_URL}/mods?status=verified&gameVersion=${version.BSVersion}&gameName=BeatSaber&platform=${platform}`;
     }


### PR DESCRIPTION
`/mods` endpoint is now deprecated.  
Would be nice to use `/multi/hashlookup` instead of `/hashlookup`.  

Other changes are in [this Discord message](https://discord.com/channels/487688050927992842/1266408573999644732/1383131613227122869).
