### PR TITLE
[fix] added error logging when getting the steam version path

### DIFF
--- a/src/main/services/bs-local-version.service.ts
+++ b/src/main/services/bs-local-version.service.ts
@@ -244,8 +244,12 @@ export class BSLocalVersionService {
     private async getSteamVersion(): Promise<BSVersion> {
         const steamBsFolder = await this.steamService.getGameFolder(BS_APP_ID, "Beat Saber");
 
-        if (!steamBsFolder || !(await pathExists(steamBsFolder))) {
-            return null;
+        if (!steamBsFolder) {
+            throw new Error("No Beat Saber Steam version found");
+        }
+
+        if (!(await pathExists(steamBsFolder))) {
+            throw new Error(`Beat Saber Steam version not found in "${steamBsFolder}"`);
         }
 
         return this.getVersionOfBSFolder(steamBsFolder, { steam: true });
@@ -265,7 +269,8 @@ export class BSLocalVersionService {
         const versions: BSVersion[] = [];
 
         const steamVersion = await this.getSteamVersion().catch(e => {
-            log.error("unable to get original Steam version", e);
+            log.error("Unable to get original Steam version", e);
+            return null;
         });
 
         if (steamVersion) {


### PR DESCRIPTION
Issue described in [discord](https://discord.com/channels/1049624409276694588/1383895325160243281)

Should log the steam path in case of an error occurring for faster debugging with users.