### PR TITLE
[bugfix] Fix "exclude installed" filter not loading more maps

### DIFF
--- a/src/renderer/components/modal/modal-types/download-maps-modal.component.tsx
+++ b/src/renderer/components/modal/modal-types/download-maps-modal.component.tsx
@@ -119,7 +119,7 @@ export const DownloadMapsModal: ModalComponent<void, { version: BSVersion; owned
                 setMaps(prev => [...prev, ...maps])
 
                 if (maps.length < tryToLoad) {
-                    handleLoadMore();
+                    handleLoadMore(false);
 
                     return;
                 }
@@ -185,9 +185,9 @@ export const DownloadMapsModal: ModalComponent<void, { version: BSVersion; owned
         setSearchParams(() => searchParamsLocal);
     };
 
-    const handleLoadMore = () => {
+    const handleLoadMore = (skipLoading: boolean = true) => {
 
-        if(loading){ return; }
+        if(skipLoading && loading){ return; }
 
         setSearchParams(prev => {
             return { ...prev, page: prev.page + 1 };


### PR DESCRIPTION
Maps weren't loading when only a few remained.