### PR TITLE
Add workaround for headset with canted views

### DIFF
--- a/src/__tests__/unit/os.test.ts
+++ b/src/__tests__/unit/os.test.ts
@@ -51,6 +51,7 @@ describe("Test os.helpers bsmSpawn", () => {
                 STEAM_COMPAT_CLIENT_INSTALL_PATH: "/steam",
                 STEAM_COMPAT_APP_ID: BS_APP_ID,
                 SteamEnv: "1",
+                OXR_PARALLEL_VIEWS: "1",
             });
         }
     });
@@ -140,7 +141,8 @@ describe("Test os.helpers bsmSpawn", () => {
             "STEAM_COMPAT_INSTALL_PATH",
             "STEAM_COMPAT_CLIENT_INSTALL_PATH",
             "STEAM_COMPAT_APP_ID",
-            "SteamEnv"
+            "SteamEnv",
+            "OXR_PARALLEL_VIEWS"
         ];
         const newEnv = {
             ...BS_ENV,

--- a/src/main/services/bs-launcher/abstract-launcher.service.ts
+++ b/src/main/services/bs-launcher/abstract-launcher.service.ts
@@ -73,6 +73,7 @@ export abstract class AbstractLauncherService {
                     "STEAM_COMPAT_CLIENT_INSTALL_PATH",
                     "STEAM_COMPAT_APP_ID",
                     "SteamEnv",
+                    "OXR_PARALLEL_VIEWS",
                     "PROTON_LOG",
                     "PROTON_LOG_DIR",
                 ],

--- a/src/main/services/linux.service.ts
+++ b/src/main/services/linux.service.ts
@@ -105,6 +105,8 @@ export class LinuxService {
             "STEAM_COMPAT_APP_ID": BS_APP_ID,
             // Run game in steam environment; fixes #585 for unicode song titles
             "SteamEnv": "1",
+            // Fix reflections in Monado
+            "OXR_PARALLEL_VIEWS": "1",
         };
 
         if (launchOptions.launchMods?.includes(LaunchMods.PROTON_LOGS)) {


### PR DESCRIPTION
See https://gitlab.freedesktop.org/monado/monado/-/merge_requests/2312

<!--

Please use the content below as a template for your pull request.
Feel free to remove sections which do not make sense.

-->

## Scope

<!-- Brief description of WHAT you’re doing and WHY. -->

Reflections in beat saber can look wrong when running with monado + openvr translator

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

I tried to use the launch options menu to customize this at first but couldn't get it to work. Since OXR_PARALLEL_VIEWS only affect canted views headsets and only recognized by Monado, it should be safe to set by default and not affect other headset/setups.

## How to Test

<!--

A straightforward scenario of how to test your changes could help colleagues that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

Need a headset with canted views like the Index and run with monado, reflections should look cross-eyed by default and with this change it should look correct.

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
