### PR TITLE
[bugfix] Adjust steam path on Linux (#922)

### DIFF
--- a/src/main/services/steam.service.ts
+++ b/src/main/services/steam.service.ts
@@ -76,7 +76,7 @@ export class SteamService {
 
         switch (process.platform) {
             case "linux":
-                this.steamPath = path.join(app.getPath("home"), ".steam", "steam");
+                this.steamPath = path.join(app.getPath("home"), "Steam");
                 return this.steamPath;
             case "win32": {
                 const res = await list(["HKLM\\SOFTWARE\\Valve\\Steam", "HKLM\\SOFTWARE\\WOW6432Node\\Valve\\Steam"]);


### PR DESCRIPTION
[bugfix] Adjust steam path after changing getPath("home") to $XDG_DATA_HOME (#922)

<!--

Please use the content below as a template for your pull request.
Feel free to remove sections which do not make sense.

-->

## Scope

<!-- Brief description of WHAT you’re doing and WHY. -->

[closes TICKET-922](https://github.com/Zagrios/bs-manager/issues/922)

## Implementation

Use `$HOME/.local/share/Steam` as location. `getPath("home")` results in `$HOME/.local/share` already, so just "Steam" needs to be added (capital).

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

<!--
## Screenshots

| before | after |
| ------ | ----- |
|        |       |
-->

<!--

## How to Test

A straightforward scenario of how to test your changes could help colleagues that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

<!--
## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |

-->