### PR TITLE
[feat-930] added added date sorting for maps/songs

### DIFF
--- a/assets/jsons/translations/en.json
+++ b/assets/jsons/translations/en.json
@@ -111,7 +111,8 @@
                             "bpm": "BPM",
                             "duration": "Duration",
                             "likes": "Likes",
-                            "date-uploaded": "Date Uploaded"
+                            "date-uploaded": "Date Uploaded",
+                            "added-date": "Added Date"
                         }
                     },
                     "playlists": {

--- a/src/main/services/additional-content/maps/local-maps-manager.service.ts
+++ b/src/main/services/additional-content/maps/local-maps-manager.service.ts
@@ -1,13 +1,13 @@
 import path from "path";
 import { BSVersion } from "shared/bs-version.interface";
 import { BsvMapDetail } from "shared/models/maps";
-import { BsmLocalMap, BsmLocalMapsProgress, DeleteMapsProgress } from "shared/models/maps/bsm-local-map.interface";
+import { BsmLocalMap, BsmLocalMapMetadata, BsmLocalMapsProgress, DeleteMapsProgress } from "shared/models/maps/bsm-local-map.interface";
 import { BSLocalVersionService } from "../../bs-local-version.service";
 import { InstallationLocationService } from "../../installation-location.service";
 import { UtilsService } from "../../utils.service";
 import crypto, { BinaryLike } from "crypto";
 import { lstatSync } from "fs";
-import { copy, createReadStream, ensureDir, pathExists, pathExistsSync, realpath } from "fs-extra";
+import { copy, createReadStream, ensureDir, existsSync, pathExists, pathExistsSync, readJson, realpath, writeJson } from "fs-extra";
 import { RequestService } from "../../request.service";
 import sanitize from "sanitize-filename";
 import { DeepLinkService } from "../../deep-link.service";
@@ -31,6 +31,7 @@ import { CustomError } from "shared/models/exceptions/custom-error.class";
 import { tryit } from "shared/helpers/error.helpers";
 import { BsmZipExtractor } from "main/models/bsm-zip-extractor.class";
 import { escapeRegExp } from "../../../../shared/helpers/string.helpers";
+import dateFormat from "dateformat";
 
 export class LocalMapsManagerService {
     private static instance: LocalMapsManagerService;
@@ -46,6 +47,7 @@ export class LocalMapsManagerService {
     public static readonly CUSTOM_LEVELS_FOLDER = "CustomLevels";
     public static readonly RELATIVE_MAPS_FOLDER = path.join(LocalMapsManagerService.LEVELS_ROOT_FOLDER, LocalMapsManagerService.CUSTOM_LEVELS_FOLDER);
     public static readonly SHARED_MAPS_FOLDER = "SharedMaps";
+    public static readonly METADATA_FILE = "metadata.json";
 
     private readonly DEEP_LINKS = {
         BeatSaver: "beatsaver",
@@ -138,16 +140,21 @@ export class LocalMapsManagerService {
 
     public async loadMapInfoFromPath(mapPath: string): Promise<BsmLocalMap> {
 
-        const getUrlsAndReturn = (mapInfo: MapInfo, hash: string, mapPath: string): BsmLocalMap => {
+        const getUrlsAndReturn = (mapInfo: MapInfo, hash: string, mapPath: string, metadata: BsmLocalMapMetadata): BsmLocalMap => {
             const coverUrl = pathToFileURL(path.join(mapPath, mapInfo.coverImageFilename)).href;
             const songUrl = pathToFileURL(path.join(mapPath, mapInfo.songFilename)).href;
-            return { mapInfo, coverUrl, songUrl, hash, path: mapPath, songDetails: this.songDetailsCache.getSongDetails(hash) };
+            return {
+                mapInfo, coverUrl, songUrl, hash, path: mapPath,
+                songDetails: this.songDetailsCache.getSongDetails(hash),
+                metadata,
+            };
         };
 
         const cachedMapInfos = this.songCache.getMapInfoFromDirname(path.basename(mapPath));
 
         if (cachedMapInfos) {
-            return getUrlsAndReturn(cachedMapInfos.mapInfo, cachedMapInfos.hash, mapPath);
+            const metadata = await this.getMetadata(mapPath);
+            return getUrlsAndReturn(cachedMapInfos.mapInfo, cachedMapInfos.hash, mapPath, metadata);
         }
 
         const files = await getFilesInFolder(mapPath);
@@ -166,8 +173,9 @@ export class LocalMapsManagerService {
         }
 
         const hash = await this.computeMapHash(mapPath, rawInfoString);
+        const metadata = await this.getMetadata(mapPath);
 
-        return getUrlsAndReturn(mapInfo, hash, mapPath);
+        return getUrlsAndReturn(mapInfo, hash, mapPath, metadata);
     }
 
     private async downloadMapZip(zipUrl: string): Promise<string> {
@@ -460,6 +468,21 @@ export class LocalMapsManagerService {
         this._lastDownloadedMap.next({ map: localMap, version });
 
         return localMap;
+    }
+
+    private async getMetadata(mapPath: string): Promise<BsmLocalMapMetadata> {
+        const metadataPath = path.join(mapPath, LocalMapsManagerService.METADATA_FILE);
+        if (existsSync(metadataPath)) {
+            return await readJson(metadataPath) as BsmLocalMapMetadata;
+        }
+
+        // Create the metadata then return it to the user
+        const metadata: BsmLocalMapMetadata = {
+            addedDate: dateFormat(new Date(), "yyyy-mm-dd'T'hh:MM:ss.l"),
+        };
+
+        await writeJson(metadataPath, metadata);
+        return metadata;
     }
 
     public async exportMaps(version: BSVersion, maps: BsmLocalMap[], outPath: string): Promise<Observable<Progression>> {

--- a/src/shared/models/maps/bsm-local-map.interface.ts
+++ b/src/shared/models/maps/bsm-local-map.interface.ts
@@ -8,6 +8,12 @@ export interface BsmLocalMap {
     mapInfo: MapInfo;
     songDetails?: SongDetails;
     path: string;
+    metadata?: BsmLocalMapMetadata;
+}
+
+export interface BsmLocalMapMetadata {
+    // Date of download or import
+    addedDate: string;
 }
 
 export interface BsmLocalMapsProgress {

--- a/src/shared/models/maps/sorter.ts
+++ b/src/shared/models/maps/sorter.ts
@@ -35,6 +35,13 @@ export const mapSorter = new Sorter<BsmLocalMap>({
 
             return !map2.songDetails ? Comparison.GREATER : map1.songDetails.uploadedAt - map2.songDetails.uploadedAt;
         },
+        "added-date": (map1, map2) => {
+            if (!map1.metadata) {
+                return map2.metadata ? Comparison.LESSER : Comparison.EQUAL;
+            }
+
+            return !map2.metadata ? Comparison.GREATER : map1.metadata.addedDate.localeCompare(map2.metadata.addedDate);
+        }
     },
     tiebreak: sortName,
     defaultKey: "name"


### PR DESCRIPTION
Closes #930

Added a way to sort maps depending on when they were added on the system.

Maintainer Notes:
Current label: `Added Date` (there might be better label for this)