### PR TITLE
Switch out old issue creation links with templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@
   </p>
   <p>
     <a
-      href="https://github.com/Zagrios/bs-manager/issues/new?assignees=Zagrios&labels=bug&template=-bug--bug-report.md&title=%5BBUG%5D+%3A+">Report
+      href="hhttps://github.com/Zagrios/bs-manager/issues/new?template=1-bug-report.yaml">Report
       Bug</a>
     ·
     <a
-      href="https://github.com/Zagrios/bs-manager/issues/new?assignees=Zagrios&labels=enhancement&template=-feat---feature-request.md&title=%5BFEAT.%5D+%3A+">Request
+      href="https://github.com/Zagrios/bs-manager/issues/new?template=2-feature-request.yaml">Request
       Feature</a>
     ·
     <a href="https://github.com/Zagrios/bs-manager/security/policy">Report a security vulnerability</a>

--- a/src/renderer/pages/settings-page.component.tsx
+++ b/src/renderer/pages/settings-page.component.tsx
@@ -247,8 +247,8 @@ export function SettingsPage() {
 
     const openSupportPage = () => linkOpener.open("https://www.patreon.com/bsmanager");
     const openGithub = () => linkOpener.open("https://github.com/Zagrios/bs-manager");
-    const openReportBug = () => linkOpener.open("https://github.com/Zagrios/bs-manager/issues/new?assignees=Zagrios&labels=bug&template=-bug--bug-report.md&title=%5BBUG%5D+%3A+");
-    const openRequestFeatures = () => linkOpener.open("https://github.com/Zagrios/bs-manager/issues/new?assignees=Zagrios&labels=enhancement&template=-feat---feature-request.md&title=%5BFEAT.%5D+%3A+");
+    const openReportBug = () => linkOpener.open("https://github.com/Zagrios/bs-manager/issues/new?template=1-bug-report.yaml");
+    const openRequestFeatures = () => linkOpener.open("https://github.com/Zagrios/bs-manager/issues/new?template=2-feature-request.yaml");
     const openDiscord = () => linkOpener.open(DISCORD_URL);
     const openTwitter = () => linkOpener.open("https://twitter.com/BSManager_");
 


### PR DESCRIPTION
Very simple PR, just switches out the older links for the newer templates. Should help a user make a bug report or feature request easier.

<img width="737" height="493" alt="image" src="https://github.com/user-attachments/assets/3cef8874-3b36-4941-9ba7-468c59080f20" />

I know its such a small thing, so denying this won't hurt my feelings.