### PR TITLE
fix bsipa installation error on linux #945

### DIFF
--- a/src/main/services/mods/bs-mods-manager.service.ts
+++ b/src/main/services/mods/bs-mods-manager.service.ts
@@ -156,7 +156,7 @@ export class BsModsManagerService {
             return false;
         }
 
-        const env: Record<string, string> = {};
+        const env: Record<string, string> = { ...process.env };
         const cmd = `"${ipaPath}" "${bsExePath}" ${args.join(" ")}`;
         let winePath: string = "";
         if (process.platform === "linux") {
@@ -176,7 +176,6 @@ export class BsModsManagerService {
                 throw new CustomError("Could not find BSManager WINEPREFIX path", "no-wineprefix");
             }
             env.WINEPREFIX = winePrefix;
-            Object.assign(env, process.env);
         }
 
         return new Promise<boolean>(resolve => {


### PR DESCRIPTION
Previously, attempting to install the BSIPA core mod would cause it to fail with the error "Game does not seem to be a Unity project. Could not find the libraries to patch." This is because the env was being overwritten after applying the WINEPREFIX, this causes BSIPA installation fail because winepath will use the drives configured in whatever the default prefix is, my Linux root was set to `U:` which is different to `Z:` used by the proper prefix. 

This PR initializes the env with the process.env and then writes the prefix. This closes #945

<img width="2426" height="229" alt="image" src="https://github.com/user-attachments/assets/0678ea1f-9ac3-497a-b18e-06882c414e06" />

## Test

1. Be on Linux using any version of Proton
2. Open a installation with BSIPA not yet installed. 
3. Press install button.
4. Observe that it successfully installs now.

I have not tested it on Windows yet so if someone could do that before approving that would be greatly appreciated, I don't see why it wouldn't work though since the changed code is basically all under a Linux check. 