### PR TITLE
Fix error prompted when uninstalling BSIPA but in fact was successfully uninstalled

### DIFF
--- a/src/main/helpers/fs.helpers.ts
+++ b/src/main/helpers/fs.helpers.ts
@@ -32,7 +32,7 @@ export async function deleteFile(filepath: string) {
         log.info("Deleting file", `"${filepath}"`);
         await unlink(filepath);
     } catch (error: any) {
-        log.error("Could not delete file", `"${filepath}"`);
+        log.error("Could not delete file", `"${filepath}"`, error);
         throw CustomError.fromError(error, "generic.fs.delete-file");
     }
 }
@@ -42,7 +42,7 @@ export function deleteFileSync(filepath: string) {
         log.info("Deleting file", `"${filepath}"`);
         unlinkSync(filepath);
     } catch (error: any) {
-        log.error("Could not delete file", `"${filepath}"`);
+        log.error("Could not delete file", `"${filepath}"`, error);
         throw CustomError.fromError(error, "generic.fs.delete-file");
     }
 }

--- a/src/main/services/mods/bs-mods-manager.service.ts
+++ b/src/main/services/mods/bs-mods-manager.service.ts
@@ -329,7 +329,9 @@ export class BsModsManagerService {
 
         const promises = mod.version.contentHashes.map(content => {
             const file = content.path.replaceAll("IPA/", "").replaceAll("Data", "Beat Saber_Data");
-            return deleteFile(path.join(verionPath, file));
+            return deleteFile(path.join(verionPath, file)).catch(err => {
+                log.info("Unable to delete IPA file, likely because it has been removed by the --revert command. Here is the error:", err);
+            });
         });
 
         await Promise.all(promises);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improve delete-file logging and silence expected delete errors during BSIPA uninstall after IPA --revert.
> 
> - **Mods Service (`src/main/services/mods/bs-mods-manager.service.ts`)**:
>   - `uninstallBSIPA`: wraps per-file `deleteFile(...)` in `.catch(...)` to log and ignore expected missing files after `IPA --revert`.
> - **FS Helpers (`src/main/helpers/fs.helpers.ts`)**:
>   - `deleteFile` and `deleteFileSync`: include the caught `error` in `log.error(...)` for better diagnostics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c592e6a475297ca69b833f2fc615045b955949e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->