### PR TITLE
fix: Playlist search modal losing state

### DIFF
--- a/src/renderer/components/modal/modal.component.tsx
+++ b/src/renderer/components/modal/modal.component.tsx
@@ -74,9 +74,9 @@ export function Modal() {
 
     return (
             <AnimatePresence>
-                {currentModal ? <motion.span key={crypto.randomUUID()} onClick={onOverlayClicked} className="fixed size-full bg-black z-[90]" initial={{ opacity: 0 }} animate={{ opacity: currentModal && 0.6 }} exit={{ opacity: 0 }} transition={{ duration: 0.2 }} /> : undefined}
+                {currentModal ? <motion.span key="modal-overlay" onClick={onOverlayClicked} className="fixed size-full bg-black z-[90]" initial={{ opacity: 0 }} animate={{ opacity: currentModal && 0.6 }} exit={{ opacity: 0 }} transition={{ duration: 0.2 }} /> : undefined}
                 {modals?.map(modal => (
-                    <motion.div key={crypto.randomUUID()} className="fixed z-[90] top-1/2 left-1/2" initial={{ y: "100vh", x: "-50%" }} animate={{y: "-50%", scale: modal === currentModal ? 1 : 0, opacity: modal === currentModal ? 1 : 0, display: modal === currentModal ? "block" : ["block", "none"]}} exit={{ y: "100vh" }}>
+                    <motion.div key={modal.id} className="fixed z-[90] top-1/2 left-1/2" initial={{ y: "100vh", x: "-50%" }} animate={{y: "-50%", scale: modal === currentModal ? 1 : 0, opacity: modal === currentModal ? 1 : 0, display: modal === currentModal ? "block" : ["block", "none"]}} exit={{ y: "100vh" }}>
                         {renderModal(modal)}
                     </motion.div>
                 ))}

--- a/src/renderer/services/modale.service.ts
+++ b/src/renderer/services/modale.service.ts
@@ -24,7 +24,7 @@ export class ModalService {
         const promise = new Promise<ModalResponse<T>>(resolve => {
             resolver = resolve as (value: ModalResponse | PromiseLike<ModalResponse>) => void;
         });
-        const modalObj = {modal: modal as ModalComponent, resolver, options};
+        const modalObj = {id: crypto.randomUUID(), modal: modal as ModalComponent, resolver, options};
         this._modalToShow$.next([...this._modalToShow$.getValue(), modalObj]);
 
         promise.then(() => {
@@ -41,7 +41,7 @@ export class ModalService {
 
 export type ModalOptions<T = unknown> = { readonly data?: T, readonly noStyle?: boolean, readonly closable?: boolean }
 export type ModalComponent<Return = unknown, Receive = unknown> = ({ resolver, options }: { readonly resolver: (x: ModalResponse<Return>) => void; readonly options?: ModalOptions<Receive> }) => JSX.Element;
-export type ModalObject = {modal: ModalComponent, resolver: (value: ModalResponse | PromiseLike<ModalResponse>) => void, options: ModalOptions};
+export type ModalObject = {id: string, modal: ModalComponent, resolver: (value: ModalResponse | PromiseLike<ModalResponse>) => void, options: ModalOptions};
 
 export const enum ModalExitCode {
     NO_CHOICE = -1,


### PR DESCRIPTION
## Scope

Fixed an issue where the playlist search state was reset when navigating back from playlist details view.

## Implementation

The problem was caused by React remounting modal components on every render due to unstable keys. The `Modal` component was using `crypto.randomUUID()` as the `key` prop for each modal on every render, causing React to treat modals as new components and lose their internal state.

**Changes made:**

1. **Added stable ID to `ModalObject` type** (`modale.service.ts`):
   - Added an `id: string` field to the `ModalObject` type definition

2. **Generate ID once per modal** (`modale.service.ts`):
   - Modified `openModal()` to generate a unique ID using `crypto.randomUUID()` when creating the modal object
   - This ID is now generated once and persists for the lifetime of the modal

3. **Use stable ID as React key** (`modal.component.tsx`):
   - Changed the modal rendering to use `modal.id` as the key instead of generating a new UUID on each render
   - Also changed the overlay key to a static string for consistency

This ensures that React correctly identifies modal components across re-renders, preserving their internal state (including search results, scroll position, and form data).

## Videos
# Before
https://github.com/user-attachments/assets/75327e44-5a54-42b6-bc91-b20654cc86a7

# After

https://github.com/user-attachments/assets/9ae0c047-3832-402e-94f4-77bc4526d914

## How to Test

1. Search for playlists using any search term
2. Click on any playlist to view its details
3. Close the playlist details modal
4. Verify that the search results are still displayed (previously they would be reset)

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
