### PR TITLE
[fix] Follow script redirect to get the JSON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
                 "tailwindcss-scoped-groups": "^2.0.0",
                 "tippy.js": "^6.3.7",
                 "to-ico": "^1.1.5",
+                "tough-cookie": "^6.0.0",
                 "use-double-click": "^1.0.5",
                 "use-fit-text": "^2.4.0",
                 "yauzl": "^3.2.0"
@@ -21894,10 +21895,16 @@
             }
         },
         "node_modules/psl": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-            "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
-            "license": "MIT"
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+            "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/lupomontero"
+            }
         },
         "node_modules/pump": {
             "version": "3.0.0",
@@ -21911,9 +21918,9 @@
             }
         },
         "node_modules/punycode": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -22757,6 +22764,19 @@
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.6"
+            }
+        },
+        "node_modules/request/node_modules/tough-cookie": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+            "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "psl": "^1.1.28",
+                "punycode": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=0.8"
             }
         },
         "node_modules/require-directory": {
@@ -24839,6 +24859,24 @@
                 "@popperjs/core": "^2.9.0"
             }
         },
+        "node_modules/tldts": {
+            "version": "7.0.19",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.19.tgz",
+            "integrity": "sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==",
+            "license": "MIT",
+            "dependencies": {
+                "tldts-core": "^7.0.19"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/tldts-core": {
+            "version": "7.0.19",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.19.tgz",
+            "integrity": "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==",
+            "license": "MIT"
+        },
         "node_modules/tmp": {
             "version": "0.2.5",
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
@@ -24925,15 +24963,15 @@
             }
         },
         "node_modules/tough-cookie": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-            "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+            "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "psl": "^1.1.28",
-                "punycode": "^2.1.1"
+                "tldts": "^7.0.5"
             },
             "engines": {
-                "node": ">=0.8"
+                "node": ">=16"
             }
         },
         "node_modules/tree-kill": {

--- a/package.json
+++ b/package.json
@@ -69,8 +69,6 @@
     "homepage": "https://github.com/Zagrios/bs-manager#readme",
     "devDependencies": {
         "@electron/fuses": "^1.7.0",
-        "ts-node": "^10.9.2",
-        "tsx": "^4.19.2",
         "@electron/notarize": "^2.3.0",
         "@electron/rebuild": "^3.6.0",
         "@pmmmwh/react-refresh-webpack-plugin": "0.5.5",
@@ -147,6 +145,8 @@
         "terser-webpack-plugin": "^5.3.10",
         "ts-jest": "^29.1.2",
         "ts-loader": "^9.5.1",
+        "ts-node": "^10.9.2",
+        "tsx": "^4.19.2",
         "typescript": "^5.3.3",
         "url-loader": "^4.1.1",
         "webpack": "^5.90.3",
@@ -206,6 +206,7 @@
         "tailwindcss-scoped-groups": "^2.0.0",
         "tippy.js": "^6.3.7",
         "to-ico": "^1.1.5",
+        "tough-cookie": "^6.0.0",
         "use-double-click": "^1.0.5",
         "use-fit-text": "^2.4.0",
         "yauzl": "^3.2.0"


### PR DESCRIPTION
"https://bsaber.org/bsplaylist.php/1,2,4,5,6/97fc284a.json" does not return JSON but:

```html
<html>

<body>
	<script>
document.cookie="bpc=50603fcd02d9e9b96d2846d3f5e3f978;Domain=bsaber.org;Path=/";document.location.href="http://bsaber.org/bsplaylist.php/1,2,4,5,6/97fc284a.json";
	</script>
</body>

</html>
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures JSON can be retrieved from endpoints that return an HTML script redirect instead of JSON.
> 
> - Update `RequestService` to detect `text/html` responses, extract `document.cookie` and `location.href` from the script, set the cookie via a `CookieJar`, and re-request the redirected URL with `got` as JSON
> - Add `tough-cookie` dependency and wire a `CookieJar` into requests; lockfile updates include `tough-cookie@6`, `tldts` additions, and `psl`/`punycode` bumps
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5512afda82b1a662f230834a88b9562ecb63a57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->