### PR TITLE
fix: use electron.net for beatmods.com requests to avoid Cloudflare timeouts

### DIFF
--- a/src/main/services/request.service.ts
+++ b/src/main/services/request.service.ts
@@ -32,7 +32,7 @@ export class RequestService {
     private constructor() {}
 
     private isBeatmodsUrl(url: string): boolean {
-        const hostname = new URL(url).hostname;
+        const { hostname } = new URL(url);
         return hostname === 'beatmods.com' || hostname.endsWith('.beatmods.com');
     }
 
@@ -44,7 +44,7 @@ export class RequestService {
         return new Promise<{ data: T; headers: IncomingHttpHeaders }>((resolve, reject) => {
             const request = net.request({
                 method: 'GET',
-                url: url,
+                url,
                 headers: this.baseHeaders,
             });
 
@@ -68,7 +68,7 @@ export class RequestService {
                 responseHeaders = response.headers as IncomingHttpHeaders;
 
                 // Validate HTTP status code (got throws on non-2xx by default)
-                const statusCode = response.statusCode;
+                const { statusCode } = response;
                 if (statusCode < 200 || statusCode >= 300) {
                     isResolved = true;
                     cleanup();
@@ -115,7 +115,7 @@ export class RequestService {
     public async getJSON<T = unknown>(url: string): Promise<{ data: T; headers: IncomingHttpHeaders }> {
         // Node's HTTP stack has Cloudflare compatibility issues with beatmods.com
         if (this.isBeatmodsUrl(url)) {
-            return await this.requestWithElectronNet<T>(url);
+            return this.requestWithElectronNet<T>(url);
         }
 
         const domain = (new URL(url)).hostname;
@@ -208,7 +208,7 @@ export class RequestService {
 
             const request = net.request({
                 method: 'GET',
-                url: url,
+                url,
                 headers: this.baseHeaders,
             });
 
@@ -220,7 +220,7 @@ export class RequestService {
 
             request.on('response', (response) => {
                 // Validate HTTP status code (got throws on non-2xx by default)
-                const statusCode = response.statusCode;
+                const { statusCode } = response;
                 if (statusCode < 200 || statusCode >= 300) {
                     isCompleted = true;
                     cleanup();
@@ -427,13 +427,13 @@ export class RequestService {
 
             const request = net.request({
                 method: 'GET',
-                url: url,
+                url,
                 headers: electronHeaders,
             });
 
             request.on('response', (response) => {
                 // Validate HTTP status code (got throws on non-2xx by default)
-                const statusCode = response.statusCode;
+                const { statusCode } = response;
                 if (statusCode < 200 || statusCode >= 300) {
                     isCompleted = true;
                     subscriber.error(new Error(`Download failed with status ${statusCode} for ${url}`));


### PR DESCRIPTION
## Scope

Requests to `https://beatmods.com/api/mods` may hang or timeout when executed
from the Electron main process, while the same endpoints work reliably
in browsers.

This results in an infinite "Loading mods" state for users.

- closes #705
- closes #959

---

## Implementation

Requests to `beatmods.com` are routed through Electron's Chromium network stack
using `electron.net`.

This avoids Cloudflare-related issues observed with Node.js HTTP clients on
large responses. The change is scoped only to `beatmods.com`; all other requests
remain unchanged.

---

## How to Test

1. Run the app (`npm run start`).
2. Open the Mods tab for any Beat Saber version.
3. Verify that the mods list loads correctly.

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolves Cloudflare timeouts by routing BeatMods traffic through Electron’s Chromium network stack.
> 
> - Adds `isBeatmodsUrl` and conditionally uses new `electron.net` implementations for `getJSON`, `downloadFile`, and `downloadBuffer`
> - Implements `requestWithElectronNet`, `downloadFileWithElectronNet`, and `downloadBufferWithElectronNet` with HTTP status validation, timeout/error handling, progress updates, and `content-disposition` filename support
> - Keeps existing `got`-based logic (including IPv4/IPv6 family preference caching) for non-BeatMods URLs; headers unchanged via `baseHeaders`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27c241e724c811f4467c67cdc6eb0a3a44ca72c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->