### PR TITLE
[fix]: fpfc launch delay

### DIFF
--- a/assets/jsons/translations/de.json
+++ b/assets/jsons/translations/de.json
@@ -561,6 +561,16 @@
                 "actions": {
                     "STEAM_NOT_RUNNING": "Starte Steam"
                 }
+            },
+            "warnings": {
+                "titles": {
+                    "FPFC_NEED_ADMIN": "FPFC mode setup incomplete",
+                    "UNABLE_TO_LAUNCH_STEAM": "Could not launch Steam"
+                },
+                "msg": {
+                    "FPFC_NEED_ADMIN": "BSManager needs administrator privileges to properly set up FPFC mode. Run BSManager as administrator for the best experience.",
+                    "UNABLE_TO_LAUNCH_STEAM": "Steam could not be started automatically."
+                }
             }
         },
         "steam": {

--- a/assets/jsons/translations/en.json
+++ b/assets/jsons/translations/en.json
@@ -561,6 +561,16 @@
                 "actions": {
                     "STEAM_NOT_RUNNING": "Launch Steam"
                 }
+            },
+            "warnings": {
+                "titles": {
+                    "FPFC_NEED_ADMIN": "FPFC mode setup incomplete",
+                    "UNABLE_TO_LAUNCH_STEAM": "Could not launch Steam"
+                },
+                "msg": {
+                    "FPFC_NEED_ADMIN": "BSManager needs administrator privileges to properly set up FPFC mode. Run BSManager as administrator for the best experience.",
+                    "UNABLE_TO_LAUNCH_STEAM": "Steam could not be started automatically."
+                }
             }
         },
         "steam": {

--- a/assets/jsons/translations/es.json
+++ b/assets/jsons/translations/es.json
@@ -561,6 +561,16 @@
                 "actions": {
                     "STEAM_NOT_RUNNING": "Iniciar Steam"
                 }
+            },
+            "warnings": {
+                "titles": {
+                    "FPFC_NEED_ADMIN": "FPFC mode setup incomplete",
+                    "UNABLE_TO_LAUNCH_STEAM": "Could not launch Steam"
+                },
+                "msg": {
+                    "FPFC_NEED_ADMIN": "BSManager needs administrator privileges to properly set up FPFC mode. Run BSManager as administrator for the best experience.",
+                    "UNABLE_TO_LAUNCH_STEAM": "Steam could not be started automatically."
+                }
             }
         },
         "steam": {

--- a/assets/jsons/translations/fr.json
+++ b/assets/jsons/translations/fr.json
@@ -561,6 +561,16 @@
                 "actions": {
                     "STEAM_NOT_RUNNING": "Lancer Steam"
                 }
+            },
+            "warnings": {
+                "titles": {
+                    "FPFC_NEED_ADMIN": "FPFC mode setup incomplete",
+                    "UNABLE_TO_LAUNCH_STEAM": "Could not launch Steam"
+                },
+                "msg": {
+                    "FPFC_NEED_ADMIN": "BSManager needs administrator privileges to properly set up FPFC mode. Run BSManager as administrator for the best experience.",
+                    "UNABLE_TO_LAUNCH_STEAM": "Steam could not be started automatically."
+                }
             }
         },
         "steam": {

--- a/assets/jsons/translations/it.json
+++ b/assets/jsons/translations/it.json
@@ -561,6 +561,16 @@
                 "actions": {
                     "STEAM_NOT_RUNNING": "Avvia Steam"
                 }
+            },
+            "warnings": {
+                "titles": {
+                    "FPFC_NEED_ADMIN": "FPFC mode setup incomplete",
+                    "UNABLE_TO_LAUNCH_STEAM": "Could not launch Steam"
+                },
+                "msg": {
+                    "FPFC_NEED_ADMIN": "BSManager needs administrator privileges to properly set up FPFC mode. Run BSManager as administrator for the best experience.",
+                    "UNABLE_TO_LAUNCH_STEAM": "Steam could not be started automatically."
+                }
             }
         },
         "steam": {

--- a/assets/jsons/translations/ja.json
+++ b/assets/jsons/translations/ja.json
@@ -561,6 +561,16 @@
                 "actions": {
                     "STEAM_NOT_RUNNING": "Steamを起動"
                 }
+            },
+            "warnings": {
+                "titles": {
+                    "FPFC_NEED_ADMIN": "FPFC mode setup incomplete",
+                    "UNABLE_TO_LAUNCH_STEAM": "Could not launch Steam"
+                },
+                "msg": {
+                    "FPFC_NEED_ADMIN": "BSManager needs administrator privileges to properly set up FPFC mode. Run BSManager as administrator for the best experience.",
+                    "UNABLE_TO_LAUNCH_STEAM": "Steam could not be started automatically."
+                }
             }
         },
         "steam": {

--- a/assets/jsons/translations/ko.json
+++ b/assets/jsons/translations/ko.json
@@ -561,6 +561,16 @@
                 "actions": {
                     "STEAM_NOT_RUNNING": "Steam 실행"
                 }
+            },
+            "warnings": {
+                "titles": {
+                    "FPFC_NEED_ADMIN": "FPFC mode setup incomplete",
+                    "UNABLE_TO_LAUNCH_STEAM": "Could not launch Steam"
+                },
+                "msg": {
+                    "FPFC_NEED_ADMIN": "BSManager needs administrator privileges to properly set up FPFC mode. Run BSManager as administrator for the best experience.",
+                    "UNABLE_TO_LAUNCH_STEAM": "Steam could not be started automatically."
+                }
             }
         },
         "steam": {

--- a/assets/jsons/translations/pt-br.json
+++ b/assets/jsons/translations/pt-br.json
@@ -561,6 +561,16 @@
                 "actions": {
                     "STEAM_NOT_RUNNING": "Iniciar Steam"
                 }
+            },
+            "warnings": {
+                "titles": {
+                    "FPFC_NEED_ADMIN": "FPFC mode setup incomplete",
+                    "UNABLE_TO_LAUNCH_STEAM": "Could not launch Steam"
+                },
+                "msg": {
+                    "FPFC_NEED_ADMIN": "BSManager needs administrator privileges to properly set up FPFC mode. Run BSManager as administrator for the best experience.",
+                    "UNABLE_TO_LAUNCH_STEAM": "Steam could not be started automatically."
+                }
             }
         },
         "steam": {

--- a/assets/jsons/translations/ru.json
+++ b/assets/jsons/translations/ru.json
@@ -561,6 +561,16 @@
                 "actions": {
                     "STEAM_NOT_RUNNING": "Запустить Steam"
                 }
+            },
+            "warnings": {
+                "titles": {
+                    "FPFC_NEED_ADMIN": "FPFC mode setup incomplete",
+                    "UNABLE_TO_LAUNCH_STEAM": "Could not launch Steam"
+                },
+                "msg": {
+                    "FPFC_NEED_ADMIN": "BSManager needs administrator privileges to properly set up FPFC mode. Run BSManager as administrator for the best experience.",
+                    "UNABLE_TO_LAUNCH_STEAM": "Steam could not be started automatically."
+                }
             }
         },
         "steam": {

--- a/assets/jsons/translations/tl.json
+++ b/assets/jsons/translations/tl.json
@@ -561,6 +561,16 @@
                 "actions": {
                     "STEAM_NOT_RUNNING": "I-launch ang Steam"
                 }
+            },
+            "warnings": {
+                "titles": {
+                    "FPFC_NEED_ADMIN": "FPFC mode setup incomplete",
+                    "UNABLE_TO_LAUNCH_STEAM": "Could not launch Steam"
+                },
+                "msg": {
+                    "FPFC_NEED_ADMIN": "BSManager needs administrator privileges to properly set up FPFC mode. Run BSManager as administrator for the best experience.",
+                    "UNABLE_TO_LAUNCH_STEAM": "Steam could not be started automatically."
+                }
             }
         },
         "steam": {

--- a/assets/jsons/translations/uk.json
+++ b/assets/jsons/translations/uk.json
@@ -561,6 +561,16 @@
                 "actions": {
                     "STEAM_NOT_RUNNING": "Запустити Steam"
                 }
+            },
+            "warnings": {
+                "titles": {
+                    "FPFC_NEED_ADMIN": "FPFC mode setup incomplete",
+                    "UNABLE_TO_LAUNCH_STEAM": "Could not launch Steam"
+                },
+                "msg": {
+                    "FPFC_NEED_ADMIN": "BSManager needs administrator privileges to properly set up FPFC mode. Run BSManager as administrator for the best experience.",
+                    "UNABLE_TO_LAUNCH_STEAM": "Steam could not be started automatically."
+                }
             }
         },
         "steam": {

--- a/assets/jsons/translations/zh-tw.json
+++ b/assets/jsons/translations/zh-tw.json
@@ -561,6 +561,16 @@
                 "actions": {
                     "STEAM_NOT_RUNNING": "啟動 Steam"
                 }
+            },
+            "warnings": {
+                "titles": {
+                    "FPFC_NEED_ADMIN": "FPFC mode setup incomplete",
+                    "UNABLE_TO_LAUNCH_STEAM": "Could not launch Steam"
+                },
+                "msg": {
+                    "FPFC_NEED_ADMIN": "BSManager needs administrator privileges to properly set up FPFC mode. Run BSManager as administrator for the best experience.",
+                    "UNABLE_TO_LAUNCH_STEAM": "Steam could not be started automatically."
+                }
             }
         },
         "steam": {

--- a/assets/jsons/translations/zh.json
+++ b/assets/jsons/translations/zh.json
@@ -561,6 +561,16 @@
                 "actions": {
                     "STEAM_NOT_RUNNING": "启动 Steam"
                 }
+            },
+            "warnings": {
+                "titles": {
+                    "FPFC_NEED_ADMIN": "FPFC mode setup incomplete",
+                    "UNABLE_TO_LAUNCH_STEAM": "Could not launch Steam"
+                },
+                "msg": {
+                    "FPFC_NEED_ADMIN": "BSManager needs administrator privileges to properly set up FPFC mode. Run BSManager as administrator for the best experience.",
+                    "UNABLE_TO_LAUNCH_STEAM": "Steam could not be started automatically."
+                }
             }
         },
         "steam": {

--- a/src/main/services/bs-launcher/steam-launcher.service.ts
+++ b/src/main/services/bs-launcher/steam-launcher.service.ts
@@ -38,14 +38,25 @@ export class SteamLauncherService extends AbstractLauncherService implements Sto
         return this.steam.getGameFolder(STEAMVR_APP_ID, "SteamVR");
     }
 
-    private async backupSteamVR(): Promise<void> {
+    private timedRename(src: string, dest: string): Promise<void> {
+        return Promise.race([
+            rename(src, dest),
+            new Promise<never>((_, reject) => setTimeout(() => reject(new Error("Rename timed out")), 5000)),
+        ]);
+    }
+
+    private async backupSteamVR(): Promise<boolean> {
         const steamVrFolder = await this.getSteamVRPath();
-        if (!(await pathExists(steamVrFolder))) {
-            return;
+        if (!steamVrFolder || !(await pathExists(steamVrFolder))) {
+            return false;
         }
-        return rename(steamVrFolder, `${steamVrFolder}.bak`).catch(err => {
-            log.error("Error while create backup of SteamVR", err);
-        });
+        try {
+            await this.timedRename(steamVrFolder, `${steamVrFolder}.bak`);
+            return false;
+        } catch (err) {
+            log.warn("Could not backup SteamVR folder, skipping", err);
+            return err?.code === "EPERM" || err?.message?.includes("timed out");
+        }
     }
 
     private getStartBsAsAdminExePath(): string {
@@ -54,14 +65,11 @@ export class SteamLauncherService extends AbstractLauncherService implements Sto
 
     public async restoreSteamVR(): Promise<void> {
         const steamVrFolder = await this.getSteamVRPath();
+        if (!steamVrFolder) { return; }
         const steamVrBackup = `${steamVrFolder}.bak`;
-
-        if (!(await pathExists(steamVrBackup))) {
-            return;
-        }
-
-        return rename(steamVrBackup, steamVrFolder).catch(err => {
-            log.error("Error while restoring SteamVR", err);
+        if (!(await pathExists(steamVrBackup))) { return; }
+        return this.timedRename(steamVrBackup, steamVrFolder).catch(err => {
+            log.warn("Could not restore SteamVR folder", err);
         });
     }
 
@@ -136,12 +144,16 @@ export class SteamLauncherService extends AbstractLauncherService implements Sto
                 obs.next({ type: BSLaunchEvent.SKIPPING_STEAM_LAUNCH});
             }
 
-            // Backup SteamVR when desktop mode is enabled
-            if(launchOptions.launchMods?.includes(LaunchMods.FPFC)){
-                await this.backupSteamVR().catch(() => {
-                    return this.restoreSteamVR();
+            const isFpfc = launchOptions.launchMods?.includes(LaunchMods.FPFC);
+            const isOculus = launchOptions.launchMods?.includes(LaunchMods.OCULUS);
+            if(isFpfc && !isOculus){
+                const backupPermError = await this.backupSteamVR().catch(() => {
+                    return this.restoreSteamVR().then(() => false);
                 });
-            } else {
+                if(backupPermError){
+                    obs.next({type: BSLaunchWarning.FPFC_NEED_ADMIN});
+                }
+            } else if(!isFpfc) {
                 await this.restoreSteamVR().catch(log.error);
             }
 

--- a/src/main/services/bs-launcher/steam-launcher.service.ts
+++ b/src/main/services/bs-launcher/steam-launcher.service.ts
@@ -39,10 +39,10 @@ export class SteamLauncherService extends AbstractLauncherService implements Sto
     }
 
     private timedRename(src: string, dest: string): Promise<void> {
-        return Promise.race([
-            rename(src, dest),
-            new Promise<never>((_, reject) => setTimeout(() => reject(new Error("Rename timed out")), 5000)),
-        ]);
+        return new Promise<void>((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error("Rename timed out")), 5000);
+            rename(src, dest).then(resolve, reject).finally(() => clearTimeout(timeout));
+        });
     }
 
     private async backupSteamVR(): Promise<boolean> {

--- a/src/renderer/services/bs-launcher.service.ts
+++ b/src/renderer/services/bs-launcher.service.ts
@@ -45,10 +45,15 @@ export class BSLauncherService {
     }
 
     private handleLaunchEvents(events$: Observable<BSLaunchEventData>): Observable<BSLaunchEventData>{
-        const eventToFilter = [...Object.values(BSLaunchWarning), BSLaunchEvent.STEAM_LAUNCHED]
+        const warningTypes: string[] = Object.values(BSLaunchWarning);
+        const eventToFilter = [...warningTypes, BSLaunchEvent.STEAM_LAUNCHED]
 
         return events$.pipe(tap({
             next: event => {
+                if(warningTypes.includes(event.type)){
+                    this.notificationService.notifyWarning({title: `notifications.bs-launch.warnings.titles.${event.type}`, desc: `notifications.bs-launch.warnings.msg.${event.type}`, duration: sToMs(9)});
+                    return;
+                }
                 if(eventToFilter.includes(event.type)){ return; }
                 this.notificationService.notifySuccess({title: `notifications.bs-launch.success.titles.${event.type}`, desc: `notifications.bs-launch.success.msg.${event.type}`});
             },

--- a/src/renderer/services/bs-launcher.service.ts
+++ b/src/renderer/services/bs-launcher.service.ts
@@ -46,7 +46,7 @@ export class BSLauncherService {
 
     private handleLaunchEvents(events$: Observable<BSLaunchEventData>): Observable<BSLaunchEventData>{
         const warningTypes: string[] = Object.values(BSLaunchWarning);
-        const eventToFilter = [...warningTypes, BSLaunchEvent.STEAM_LAUNCHED]
+        const eventToFilter = [BSLaunchEvent.STEAM_LAUNCHED]
 
         return events$.pipe(tap({
             next: event => {

--- a/src/renderer/services/bs-launcher.service.ts
+++ b/src/renderer/services/bs-launcher.service.ts
@@ -46,7 +46,6 @@ export class BSLauncherService {
 
     private handleLaunchEvents(events$: Observable<BSLaunchEventData>): Observable<BSLaunchEventData>{
         const warningTypes: string[] = Object.values(BSLaunchWarning);
-        const eventToFilter = [BSLaunchEvent.STEAM_LAUNCHED]
 
         return events$.pipe(tap({
             next: event => {
@@ -54,7 +53,7 @@ export class BSLauncherService {
                     this.notificationService.notifyWarning({title: `notifications.bs-launch.warnings.titles.${event.type}`, desc: `notifications.bs-launch.warnings.msg.${event.type}`, duration: sToMs(9)});
                     return;
                 }
-                if(eventToFilter.includes(event.type)){ return; }
+                if(event.type === BSLaunchEvent.STEAM_LAUNCHED){ return; }
                 this.notificationService.notifySuccess({title: `notifications.bs-launch.success.titles.${event.type}`, desc: `notifications.bs-launch.success.msg.${event.type}`});
             },
             error: (err: CustomError) => {

--- a/src/shared/models/bs-launch/launch-event.model.ts
+++ b/src/shared/models/bs-launch/launch-event.model.ts
@@ -29,6 +29,7 @@ export enum BSLaunchEvent{
 
 export enum BSLaunchWarning{
     UNABLE_TO_LAUNCH_STEAM = "UNABLE_TO_LAUNCH_STEAM",
+    FPFC_NEED_ADMIN = "FPFC_NEED_ADMIN",
 }
 
 export type BSLaunchEventType = BSLaunchEvent | BSLaunchWarning;


### PR DESCRIPTION
## Scope

fpfc launch takes 60+ seconds when steamvr lives in a protected dir (annoyingly even happens in oculus mode on the steam version of the game)

this seems to have been around for awhile, unsure how it hasn't been reported; anyway.. I've recently simplified my pc (big nvme, one partition) so i'd never run into this issue before as stuff was usually installed outside of `C:\`

anywho bsmanager backs up steamvr (`SteamVR` -> `SteamVR.bak`) before every fpfc launch to prevent steamvr from opening alongside the game and runs even when oculus mode is enabled even though `-vrmode oculus` bypasses steamvr entirely, so that backup is pointless. if steam is installed somewhere like program files, the rename hangs for ~60 seconds waiting on an EPERM before failing and moving on.

## Implementation

- skip the steamvr backup entirely when oculus mode is enabled -- it's not needed
- for the non oculus fpfc case, wrap the rename in a 5s timeout so a permission failure doesn't stall the whole launch, and show a warning toast telling the user that running the program as admin would give them a much better time
- actually wired up the `BSLaunchWarning` events to actually show toast notifications, looks like they were silently filtered out before

## How to Test

- steam in a protected directory like `C:\Program Files (x86)\Steam`, bsmanager running without admin
- launch any version with fpfc + oculus mode enabled -- should launch near instantly
- launch with fpfc only (no oculus mode) -- should launch within a few seconds, admin warning toast should appear
