### PR TITLE
fix: show installed mods not in BeatMods verified list

### DIFF
--- a/src/main/services/mods/bs-mods-manager.service.ts
+++ b/src/main/services/mods/bs-mods-manager.service.ts
@@ -460,7 +460,19 @@ export class BsModsManagerService {
                 return [];
             }
 
-            return await zip.extract(destination);
+            const hasStructuredLayout = await zip.findEntry(entry => {
+                const normalized = entry.fileName.replace(/\\/g, "/");
+                return normalized.startsWith("Plugins/") || normalized.startsWith("Libs/");
+            });
+
+            if (hasStructuredLayout) {
+                log.info("ZIP has structured layout, extracting directly to", `"${destination}"`);
+                return await zip.extract(destination);
+            }
+
+            const pluginsDestination = path.join(destination, ModsInstallFolder.PLUGINS);
+            log.info("ZIP has flat layout, extracting to", `"${pluginsDestination}"`);
+            return await zip.extract(pluginsDestination);
         } catch (error) {
             log.warn("Could not extract", `"${modPath}"`, error);
             return [];

--- a/src/main/services/mods/bs-mods-manager.service.ts
+++ b/src/main/services/mods/bs-mods-manager.service.ts
@@ -461,7 +461,7 @@ export class BsModsManagerService {
             }
 
             const hasStructuredLayout = await zip.findEntry(entry => {
-                const normalized = entry.fileName.replace(/\\/g, "/");
+                const normalized = entry.fileName.replaceAll("\\", "/");
                 return normalized.startsWith("Plugins/") || normalized.startsWith("Libs/");
             });
 

--- a/src/renderer/components/version-viewer/slides/mods/mods-slide.component.tsx
+++ b/src/renderer/components/version-viewer/slides/mods/mods-slide.component.tsx
@@ -200,23 +200,24 @@ export const ModsSlide = forwardRef<ModsSlideRef, Props>(({ version, isActive, o
         return haveAccepted;
     }
 
+    const applyModsState = ({ available, installed }: { available: BbmFullMod[]; installed: BbmFullMod[] }) => {
+        // Merge installed mods not in the available (verified) list so they appear in the grid
+        const availableIds = new Set(available.map(m => m.mod.id));
+        const installedOnly = installed.filter(m => !availableIds.has(m.mod.id));
+        const allMods = [...available, ...installedOnly];
+
+        const defaultMods = installed?.length ? [] : allMods.filter(m => m.mod.category === BbmCategories.Core || m.mod.category === BbmCategories.Essential);
+        setModsAvailable(() => modsToCategoryMap(allMods));
+        setModsSelected(allMods.filter(m => m.mod.category === BbmCategories.Core || defaultMods.some(d => m.mod.name.toLowerCase() === d.mod.name.toLowerCase()) || installed.some(i => m.mod.id === i.mod.id)));
+        setModsInstalled(modsToCategoryMap(installed));
+    };
+
     const loadMods = async (): Promise<void> => {
         if (gridStatus !== ModsGridStatus.OK) {
             return Promise.resolve();
         }
 
-        return modsManager.getVersionModsState(version).then(({ available, installed }) => {
-            // Merge installed mods that aren't in the available list so they appear in the grid
-            const availableIds = new Set(available.map(m => m.mod.id));
-            const installedOnly = installed.filter(m => !availableIds.has(m.mod.id));
-            const allMods = [...available, ...installedOnly];
-
-            const defaultMods = installed?.length ? [] : allMods.filter(m => m.mod.category === BbmCategories.Core || m.mod.category === BbmCategories.Essential);
-            setModsAvailable(() => modsToCategoryMap(allMods));
-
-            setModsSelected(allMods.filter(m => m.mod.category === BbmCategories.Core || defaultMods.some(d => m.mod.name.toLowerCase() === d.mod.name.toLowerCase()) || installed.some(i => m.mod.id === i.mod.id)));
-            setModsInstalled(modsToCategoryMap(installed));
-        });
+        return modsManager.getVersionModsState(version).then(applyModsState);
     };
 
     useImperativeHandle(forwaredRef, () => ({
@@ -247,18 +248,9 @@ export const ModsSlide = forwardRef<ModsSlideRef, Props>(({ version, isActive, o
                 return;
             }
 
-            modsManager.getVersionModsState(version).then(({ available, installed }) => {
+            modsManager.getVersionModsState(version).then(state => {
                 if (isCancelled) return;
-
-                // Merge installed mods that aren't in the available list so they appear in the grid
-                const availableIds = new Set(available.map(m => m.mod.id));
-                const installedOnly = installed.filter(m => !availableIds.has(m.mod.id));
-                const allMods = [...available, ...installedOnly];
-
-                const defaultMods = installed?.length ? [] : allMods.filter(m => m.mod.category === BbmCategories.Core || m.mod.category === BbmCategories.Essential);
-                setModsAvailable(() => modsToCategoryMap(allMods));
-                setModsSelected(allMods.filter(m => m.mod.category === BbmCategories.Core || defaultMods.some(d => m.mod.name.toLowerCase() === d.mod.name.toLowerCase()) || installed.some(i => m.mod.id === i.mod.id)));
-                setModsInstalled(modsToCategoryMap(installed));
+                applyModsState(state);
             });
         });
 

--- a/src/renderer/components/version-viewer/slides/mods/mods-slide.component.tsx
+++ b/src/renderer/components/version-viewer/slides/mods/mods-slide.component.tsx
@@ -206,10 +206,15 @@ export const ModsSlide = forwardRef<ModsSlideRef, Props>(({ version, isActive, o
         }
 
         return modsManager.getVersionModsState(version).then(({ available, installed }) => {
-            const defaultMods = installed?.length ? [] : available.filter(m => m.mod.category === BbmCategories.Core || m.mod.category === BbmCategories.Essential);
-            setModsAvailable(() => modsToCategoryMap(available));
+            // Merge installed mods that aren't in the available list so they appear in the grid
+            const availableIds = new Set(available.map(m => m.mod.id));
+            const installedOnly = installed.filter(m => !availableIds.has(m.mod.id));
+            const allMods = [...available, ...installedOnly];
 
-            setModsSelected(available.filter(m => m.mod.category === BbmCategories.Core || defaultMods.some(d => m.mod.name.toLowerCase() === d.mod.name.toLowerCase()) || installed.some(i => m.mod.id === i.mod.id)));
+            const defaultMods = installed?.length ? [] : allMods.filter(m => m.mod.category === BbmCategories.Core || m.mod.category === BbmCategories.Essential);
+            setModsAvailable(() => modsToCategoryMap(allMods));
+
+            setModsSelected(allMods.filter(m => m.mod.category === BbmCategories.Core || defaultMods.some(d => m.mod.name.toLowerCase() === d.mod.name.toLowerCase()) || installed.some(i => m.mod.id === i.mod.id)));
             setModsInstalled(modsToCategoryMap(installed));
         });
     };
@@ -245,9 +250,14 @@ export const ModsSlide = forwardRef<ModsSlideRef, Props>(({ version, isActive, o
             modsManager.getVersionModsState(version).then(({ available, installed }) => {
                 if (isCancelled) return;
 
-                const defaultMods = installed?.length ? [] : available.filter(m => m.mod.category === BbmCategories.Core || m.mod.category === BbmCategories.Essential);
-                setModsAvailable(() => modsToCategoryMap(available));
-                setModsSelected(available.filter(m => m.mod.category === BbmCategories.Core || defaultMods.some(d => m.mod.name.toLowerCase() === d.mod.name.toLowerCase()) || installed.some(i => m.mod.id === i.mod.id)));
+                // Merge installed mods that aren't in the available list so they appear in the grid
+                const availableIds = new Set(available.map(m => m.mod.id));
+                const installedOnly = installed.filter(m => !availableIds.has(m.mod.id));
+                const allMods = [...available, ...installedOnly];
+
+                const defaultMods = installed?.length ? [] : allMods.filter(m => m.mod.category === BbmCategories.Core || m.mod.category === BbmCategories.Essential);
+                setModsAvailable(() => modsToCategoryMap(allMods));
+                setModsSelected(allMods.filter(m => m.mod.category === BbmCategories.Core || defaultMods.some(d => m.mod.name.toLowerCase() === d.mod.name.toLowerCase()) || installed.some(i => m.mod.id === i.mod.id)));
                 setModsInstalled(modsToCategoryMap(installed));
             });
         });

--- a/src/renderer/services/bs-mods-manager.service.ts
+++ b/src/renderer/services/bs-mods-manager.service.ts
@@ -6,7 +6,7 @@ import { ProgressBarService } from "./progress-bar.service";
 import { NotificationService } from "./notification.service";
 import { Progression } from "main/helpers/fs.helpers";
 import { ProgressionInterface } from "shared/models/progress-bar";
-import { BbmFullMod, BbmModVersion } from "shared/models/mods/mod.interface";
+import { BbmFullMod, BbmModVersion, BbmCategories, BbmStatus } from "shared/models/mods/mod.interface";
 import { logRenderError } from "renderer";
 import { ModsGridStatus } from "shared/models/mods/mod-ipc.model";
 import { LinuxService } from "./linux.service";
@@ -200,6 +200,33 @@ export class BsModsManagerService {
 
             if(mod){
                 acc.push({ ...mod, version: installedMod } as BbmFullMod);
+            } else {
+                // Mod is installed but not in the available (verified) list.
+                // Construct a minimal BbmMod so it still appears in the UI.
+                const dllHash = installedMod.contentHashes?.find(c => c.path.endsWith(".dll"));
+                const name = dllHash
+                    ? dllHash.path.replace(/^.*[\\/]/, "").replace(/\.dll$/, "")
+                    : `Unknown mod (${installedMod.modId})`;
+
+                acc.push({
+                    mod: {
+                        id: installedMod.modId,
+                        name,
+                        summary: "",
+                        description: "",
+                        gameName: "BeatSaber",
+                        category: BbmCategories.Other,
+                        authors: installedMod.author ? [installedMod.author] : [],
+                        status: installedMod.status ?? BbmStatus.Unverified,
+                        iconFileName: "",
+                        gitUrl: "",
+                        lastApprovedById: null,
+                        lastUpdatedById: null,
+                        createdAt: installedMod.createdAt ?? new Date(),
+                        updatedAt: installedMod.updatedAt ?? new Date(),
+                    },
+                    version: installedMod,
+                } as BbmFullMod);
             }
 
             return acc;


### PR DESCRIPTION
## Summary
Fixes #1022

- **Display fix**: Installed mods with `pending` or `unverified` status on BeatMods were silently dropped from the UI. `getVersionModsState()` only matched installed mods against the verified available list, so any mod not yet verified was invisible even though it was correctly installed on disk. Now constructs minimal mod metadata for unmatched installed mods and merges them into the grid.
- **ZIP extraction fix**: Flat-layout mod ZIPs (bare `.dll` at root without a `Plugins/` subdirectory) were extracted to `IPA/Pending/` instead of `IPA/Pending/Plugins/`, causing BSIPA to move them to the game root instead of `Plugins/`. Now detects ZIP layout and routes accordingly.

## Files changed
| File | Change |
|------|--------|
| `src/renderer/services/bs-mods-manager.service.ts` | Construct `BbmFullMod` for installed mods not in the available (verified) list |
| `src/renderer/components/version-viewer/slides/mods/mods-slide.component.tsx` | Merge installed-only mods into the grid data source |
| `src/main/services/mods/bs-mods-manager.service.ts` | Detect flat vs structured ZIP layout for correct extraction path |

## Test plan
- [x] Import a structured-layout mod ZIP (e.g. NoodleExtensions) → files land in `IPA/Pending/Plugins/`, mod appears in UI
- [x] Import a flat-layout mod ZIP (bare DLL at root) → files land in `IPA/Pending/Plugins/` (not `IPA/Pending/`)
- [x] Mods with `pending` BeatMods status now visible in the installed mods grid
- [x] Verified mods continue to display and install normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)