### PR TITLE
[fix-1044]: added new wine64 pathing

### DIFF
--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -19,7 +19,5 @@ export const HTTP_STATUS_CODES = constants;
 
 // Linux related stuff
 
-export const PROTON_BINARY_PREFIX = "proton";
-export const WINE_BINARY_PREFIX = path.join("files", "bin", "wine64");
 export const IS_FLATPAK = process.env.container === "flatpak";
 

--- a/src/main/services/linux.service.ts
+++ b/src/main/services/linux.service.ts
@@ -1,7 +1,7 @@
 import fs from "fs-extra";
 import log from "electron-log";
 import path from "path";
-import { BS_APP_ID, BS_EXECUTABLE, IS_FLATPAK, PROTON_BINARY_PREFIX, WINE_BINARY_PREFIX } from "main/constants";
+import { BS_APP_ID, BS_EXECUTABLE, IS_FLATPAK } from "main/constants";
 import { InstallationLocationService } from "./installation-location.service";
 import { StaticConfigurationService } from "./static-configuration.service";
 import { CustomError } from "shared/models/exceptions/custom-error.class";
@@ -22,10 +22,19 @@ export class LinuxService {
         return LinuxService.instance;
     }
 
+    private readonly PROTON_BINARY_PREFIX = "proton";
+    // Use "wine64" instead of "wine"
+    // https://github.com/Zagrios/bs-manager/pull/586#issuecomment-2449228826
+    private readonly WINE_BINARY_PREFIXES = [
+        path.join("files", "bin", "wine64"),
+        path.join("files", "lib", "wine", "x86_64-unix", "wine64"),
+    ];
+
     private readonly installLocationService: InstallationLocationService;
     private readonly staticConfig: StaticConfigurationService;
 
     private nixOS: boolean | undefined;
+    private winePath = "";
 
     private constructor() {
         this.installLocationService = InstallationLocationService.getInstance();
@@ -55,7 +64,7 @@ export class LinuxService {
         }
         const protonPath = path.join(
             this.staticConfig.get("proton-folder"),
-            PROTON_BINARY_PREFIX
+            this.PROTON_BINARY_PREFIX
         );
         if (!fs.pathExistsSync(protonPath)) {
             throw CustomError.fromError(
@@ -112,27 +121,53 @@ export class LinuxService {
             protonFolder = this.staticConfig.get("proton-folder");
         }
 
-        const protonPath = path.join(protonFolder, PROTON_BINARY_PREFIX);
-        const winePath = path.join(protonFolder, WINE_BINARY_PREFIX);
-        return fs.pathExistsSync(protonPath) && fs.pathExistsSync(winePath);
+        // Check if the proton binary exists
+        const protonPath = path.join(protonFolder, this.PROTON_BINARY_PREFIX);
+        if (!fs.pathExistsSync(protonPath)) {
+            return false;
+        }
+
+        // Check if any wine64 here exists
+        for (const winePath of this.WINE_BINARY_PREFIXES) {
+            if (fs.pathExistsSync(path.join(protonFolder, winePath))) {
+                // Reset this, in the case where the user reselects a new proton folder
+                this.winePath = "";
+                return true;
+            }
+        }
+        return false;
     }
 
     public getWinePath(): string {
+        if (this.winePath) {
+            return this.winePath;
+        }
+
         if (!this.staticConfig.has("proton-folder")) {
             throw new Error("proton-folder variable not set");
         }
 
-        const winePath = path.join(
-            this.staticConfig.get("proton-folder"),
-            WINE_BINARY_PREFIX
-        );
-        if (!fs.pathExistsSync(winePath)) {
+        const protonFolder = this.staticConfig.get("proton-folder");
+        let winePath = "";
+        for (const prefixes of this.WINE_BINARY_PREFIXES) {
+            winePath = path.join(protonFolder, prefixes);
+            if (!fs.pathExistsSync(winePath)) {
+                winePath = "";
+                continue;
+            }
+            break;
+        }
+
+        if (winePath === "") {
             throw new Error(`"${winePath}" binary file not found`);
         }
 
+        this.winePath = winePath;
         return winePath;
     }
 
+    // Should be different from winePath, this is the "WINEPREFIX" env var
+    //   that points to the wine windows files directory
     public getWinePrefixPath(): string {
         const compatDataPath = this.getCompatDataPath();
         return fs.existsSync(compatDataPath)

--- a/src/main/services/static-configuration.service.ts
+++ b/src/main/services/static-configuration.service.ts
@@ -1,9 +1,5 @@
 import ElectronStore from "electron-store";
-import { pathExistsSync } from "fs-extra";
-import path from "path";
-import { PROTON_BINARY_PREFIX, WINE_BINARY_PREFIX } from "main/constants";
 import { Observable, Subject } from "rxjs";
-import { CustomError } from "shared/models/exceptions/custom-error.class";
 import { BSVersion } from "shared/bs-version.interface";
 import { AutoUpdate } from "shared/models/config";
 
@@ -40,30 +36,10 @@ export class StaticConfigurationService {
     }
 
     public async set<K extends StaticConfigKeys>(key: K, value: StaticConfigKeyValues[K]): Promise<void> {
-        // Validate the setters
-        switch (key) {
-            case "proton-folder":
-                this.validateProtonFolder(value as string);
-                break;
-
-            default:
-                break;
-        }
-
         this.store.set(key, value);
 
         if (this.watchers[key]) {
             this.watchers[key].next(value); // update watchers if any
-        }
-    }
-
-    // Setters with validation
-
-    private validateProtonFolder(protonFolder: string): void {
-        const protonPath = path.join(protonFolder, PROTON_BINARY_PREFIX);
-        const winePath = path.join(protonFolder, WINE_BINARY_PREFIX);
-        if (!pathExistsSync(protonPath) || !pathExistsSync(winePath)) {
-            throw new CustomError("Invalid proton folder path", "invalid-folder");
         }
     }
 


### PR DESCRIPTION
Closes #1044 

Fixes:
- Removed static config validation on proton pathing. Not really a good validator, since nobody really edits their configs manually.
- Should support legacy and new pathing for the `wine64` binary.