### PR TITLE
[fix] added OXR_NO_TEXTURE_SOURCE_ALPHA=1 for monado runtime

### DIFF
--- a/src/main/services/linux.service.ts
+++ b/src/main/services/linux.service.ts
@@ -93,6 +93,7 @@ export class LinuxService {
             "SteamEnv": "1",
             // Fix reflections in Monado
             "OXR_PARALLEL_VIEWS": "1",
+            "OXR_NO_TEXTURE_SOURCE_ALPHA": "1",
         };
 
         if (launchOptions.launchMods?.includes(LaunchMods.PROTON_LOGS)) {


### PR DESCRIPTION
As discussed in LVRA. Added `OXR_NO_TEXTURE_SOURCE_ALPHA=1` to properly render the game in monado.