### PR TITLE
Update FPFC to prevent SteamVR launch more reliably

### DIFF
--- a/src/main/services/bs-launcher/abstract-launcher.service.ts
+++ b/src/main/services/bs-launcher/abstract-launcher.service.ts
@@ -19,6 +19,10 @@ export function buildBsLaunchArgs(launchOptions: LaunchOption): string[] {
         launchArgs.push("oculus");
     }
     if(launchOptions.launchMods?.includes(LaunchMods.FPFC)) {
+        if (!launchOptions.launchMods?.includes(LaunchMods.OCULUS)) {
+            launchArgs.push("-vrmode");
+            launchArgs.push("None");
+        }
         launchArgs.push("fpfc");
     }
     if(launchOptions.launchMods?.includes(LaunchMods.DEBUG)) {
@@ -146,4 +150,3 @@ export type LaunchBeatSaberOptions = {
     // Timeout value (in ms) to unref the Beat Saber process to BSM
     unrefAfter?: number;
 }
-

--- a/src/main/services/bs-launcher/steam-launcher.service.ts
+++ b/src/main/services/bs-launcher/steam-launcher.service.ts
@@ -1,10 +1,10 @@
 import { Observable } from "rxjs";
 import { BSLaunchError, BSLaunchEvent, BSLaunchEventData, BSLaunchWarning, LaunchOption } from "../../../shared/models/bs-launch";
 import { StoreLauncherInterface } from "./store-launcher.interface";
-import { pathExists, rename } from "fs-extra";
+import { pathExists } from "fs-extra";
 import { SteamService } from "../steam.service";
 import path from "path";
-import { BS_APP_ID, BS_EXECUTABLE, STEAMVR_APP_ID } from "../../constants";
+import { BS_APP_ID, BS_EXECUTABLE } from "../../constants";
 import log from "electron-log";
 import { AbstractLauncherService, buildBsLaunchArgs, LaunchBeatSaberOptions } from "./abstract-launcher.service";
 import { CustomError } from "../../../shared/models/exceptions/custom-error.class";
@@ -34,39 +34,18 @@ export class SteamLauncherService extends AbstractLauncherService implements Sto
         this.util = UtilsService.getInstance();
     }
 
-    private getSteamVRPath(): Promise<string> {
-        return this.steam.getGameFolder(STEAMVR_APP_ID, "SteamVR");
-    }
-
-    private async backupSteamVR(): Promise<void> {
-        const steamVrFolder = await this.getSteamVRPath();
-        if (!(await pathExists(steamVrFolder))) {
-            return;
-        }
-        return rename(steamVrFolder, `${steamVrFolder}.bak`).catch(err => {
-            log.error("Error while create backup of SteamVR", err);
-        });
-    }
-
     private getStartBsAsAdminExePath(): string {
         return path.join(this.util.getAssetsScriptsPath(), "start_beat_saber_admin.exe");
     }
 
     public async restoreSteamVR(): Promise<void> {
-        const steamVrFolder = await this.getSteamVRPath();
-        const steamVrBackup = `${steamVrFolder}.bak`;
-
-        if (!(await pathExists(steamVrBackup))) {
-            return;
-        }
-
-        return rename(steamVrBackup, steamVrFolder).catch(err => {
-            log.error("Error while restoring SteamVR", err);
-        });
+        log.info("SteamVR restore skipped; SteamVR file/folder guard disabled");
     }
 
     protected launchBeatSaber(options: LaunchBeatSaberOptions): {process: ChildProcessWithoutNullStreams, exit: Promise<number>} {
         const process = this.launchBeatSaberProcess(options);
+
+        let timeoutId: NodeJS.Timeout;
 
         const exit = new Promise<number>((resolve, reject) => {
             // Don't remove, useful for debugging!
@@ -83,7 +62,6 @@ export class SteamLauncherService extends AbstractLauncherService implements Sto
                     event.preventDefault();
                     log.info(`Unref'ing BS process ${process.pid} on app will-quit`);
                     process.unref();
-                    await this.restoreSteamVR().catch(log.error);
                     resolve(-1);
                     app.quit();
                 }
@@ -102,6 +80,18 @@ export class SteamLauncherService extends AbstractLauncherService implements Sto
             });
 
             app.on('will-quit', onWillQuitHandler);
+
+            const unrefAfter = options?.unrefAfter ?? 1_000;
+
+            timeoutId = setTimeout(() => {
+                log.info("BS process still running after launch timeout; detaching", { pid: process.pid, unrefAfter });
+                process.unref();
+                process.removeAllListeners();
+                app.removeListener('will-quit', onWillQuitHandler);
+                resolve(-1);
+            }, unrefAfter);
+        }).finally(() => {
+            clearTimeout(timeoutId);
         });
 
         return { process, exit };
@@ -110,42 +100,68 @@ export class SteamLauncherService extends AbstractLauncherService implements Sto
     public launch(launchOptions: LaunchOption): Observable<BSLaunchEventData>{
 
         return new Observable<BSLaunchEventData>(obs => {(async () => {
+            const launchStartedAt = Date.now();
+            const logStep = (step: string, data?: Record<string, unknown>) => {
+                log.info("Steam launch step", {
+                    step,
+                    elapsedMs: Date.now() - launchStartedAt,
+                    ...data,
+                });
+            };
+
+            logStep("start", {
+                version: launchOptions.version?.BSVersion,
+                name: launchOptions.version?.name,
+                steam: launchOptions.version?.steam,
+                metadataStore: launchOptions.version?.metadata?.store,
+                launchMods: launchOptions.launchMods,
+                admin: launchOptions.admin,
+                hasCustomCommand: !!launchOptions.command,
+            });
 
             const bsFolderPath = await this.localVersions.getInstalledVersionPath(launchOptions.version);
+            logStep("resolved-version-path", { bsFolderPath });
             const bsExePath = path.join(bsFolderPath, BS_EXECUTABLE);
 
             if(!(await pathExists(bsExePath))){
                 throw CustomError.fromError(new Error(`Path not exist : ${bsExePath}`), BSLaunchError.BS_NOT_FOUND);
             }
+            logStep("validated-exe", { bsExePath });
 
             const skipSteam: boolean = launchOptions.launchMods?.includes(LaunchMods.SKIP_STEAM) ?? false;
 
             // Open Steam if not running
-            if(!skipSteam && !(await this.steam.isSteamRunning())){
+            const steamRunning = await this.steam.isSteamRunning();
+            const steamProcessRunning = steamRunning || await this.steam.isSteamProcessRunning();
+            logStep("steam-state", { skipSteam, steamRunning, steamProcessRunning });
+
+            if(!skipSteam && !steamProcessRunning){
 
                 obs.next({type: BSLaunchEvent.STEAM_LAUNCHING});
+                logStep("open-steam-start");
 
                 await this.steam.openSteam().then(() => {
                     obs.next({type: BSLaunchEvent.STEAM_LAUNCHED});
+                    logStep("open-steam-done");
                 }).catch(e => {
                     log.error(e);
                     obs.next({type: BSLaunchWarning.UNABLE_TO_LAUNCH_STEAM});
+                    logStep("open-steam-failed");
                 });
             }
             else if(skipSteam) {
                 obs.next({ type: BSLaunchEvent.SKIPPING_STEAM_LAUNCH});
+                logStep("skip-steam");
+            }
+            else if(!steamRunning) {
+                log.warn("Steam process is running, but active user is unavailable. Skipping Steam startup wait.");
+                logStep("steam-active-user-missing");
             }
 
-            // Backup SteamVR when desktop mode is enabled
-            if(launchOptions.launchMods?.includes(LaunchMods.FPFC)){
-                await this.backupSteamVR().catch(() => {
-                    return this.restoreSteamVR();
-                });
-            } else {
-                await this.restoreSteamVR().catch(log.error);
-            }
+            const fpfcEnabled = launchOptions.launchMods?.includes(LaunchMods.FPFC) ?? false;
 
             const steamPath = await this.steam.getSteamPath();
+            logStep("resolved-steam-path", { steamPath });
 
             let env: Record<string, string> = {
                 ...process.env,
@@ -153,6 +169,11 @@ export class SteamLauncherService extends AbstractLauncherService implements Sto
                 "SteamOverlayGameId": BS_APP_ID,
                 "SteamGameId": BS_APP_ID,
             };
+
+            if (process.platform === "win32" && fpfcEnabled) {
+                env.XR_RUNTIME_JSON = path.join(bsFolderPath, "BSManager_FPFC_NoOpenXR_Runtime.json");
+                log.info("Overriding OpenXR runtime for FPFC launch", { XR_RUNTIME_JSON: env.XR_RUNTIME_JSON });
+            }
 
             // Linux setup
             if (process.platform === "linux") {
@@ -177,12 +198,14 @@ export class SteamLauncherService extends AbstractLauncherService implements Sto
             env = this.mergeEnvVariables(env, parsedEnv);
 
             const launchArgs = buildBsLaunchArgs(launchOptions);
+            logStep("parsed-launch-command", { cmdlet, args, launchArgs });
 
             obs.next({type: BSLaunchEvent.BS_LAUNCHING});
 
             const spawnOpts = { env, cwd: bsFolderPath };
 
             const launchPromise = !launchOptions.admin ? (
+                logStep("spawn-bs-start"),
                 this.launchBeatSaber({
                     env, cmdlet,
                     args: args
@@ -192,6 +215,7 @@ export class SteamLauncherService extends AbstractLauncherService implements Sto
                 }).exit
             ) : (
                 new Promise<number>(resolve => {
+                    logStep("spawn-bs-admin-start");
                     const adminProcess = exec(`"${this.getStartBsAsAdminExePath()}" "${bsExePath}" ${launchArgs.join(" ")} --log-path "${path.join(app.getPath("logs"), "bs-admin-start.log")}"`, spawnOpts);
                     adminProcess.on("error", err => {
                         log.error("Error while starting BS as Admin", err);
@@ -208,12 +232,11 @@ export class SteamLauncherService extends AbstractLauncherService implements Sto
             try {
                 const exitCode = await launchPromise;
                 log.info("BS process exit code", exitCode);
+                logStep("launch-promise-resolved", { exitCode });
             }
             catch(err: any) {
+                logStep("launch-promise-error");
                 throw CustomError.fromError(err, BSLaunchError.BS_EXIT_ERROR);
-            }
-            finally {
-                await this.restoreSteamVR().catch(log.error);
             }
 
         })().then(() => {

--- a/src/main/services/steam.service.ts
+++ b/src/main/services/steam.service.ts
@@ -41,13 +41,27 @@ export class SteamService {
         return registryValue.value;
     }
 
+    public async isSteamProcessRunning(): Promise<boolean> {
+        return isProcessRunning(SteamService.PROCESS_NAME);
+    }
+
     public async isSteamRunning(): Promise<boolean> {
-        const steamProcessRunning = await isProcessRunning(SteamService.PROCESS_NAME);
+        const steamProcessRunning = await this.isSteamProcessRunning();
+        if (!steamProcessRunning) {
+            return false;
+        }
+
         if (process.platform === "linux") {
             return steamProcessRunning;
         }
-        const activeUser = await this.getActiveUser().catch(err => log.error(err));
-        return steamProcessRunning && !!activeUser;
+
+        try {
+            const activeUser = await this.getActiveUser();
+            return !!activeUser;
+        } catch (err) {
+            log.warn("Unable to read Steam active user; falling back to process detection", err);
+            return true;
+        }
     }
 
     public async getSteamPid(): Promise<number> {
@@ -96,6 +110,66 @@ export class SteamService {
         }
     }
 
+    private async getSteamRootCandidates(): Promise<string[]> {
+        const candidates = new Set<string>();
+        const steamPath = await this.getSteamPath().catch(() => null);
+
+        if (steamPath) {
+            candidates.add(steamPath);
+        }
+
+        if (process.platform === "win32") {
+            const programFiles = process.env["ProgramFiles"];
+            const programFilesX86 = process.env["ProgramFiles(x86)"];
+            if (programFiles) {
+                candidates.add(path.join(programFiles, "Steam"));
+            }
+            if (programFilesX86) {
+                candidates.add(path.join(programFilesX86, "Steam"));
+            }
+
+            for (let code = "A".charCodeAt(0); code <= "Z".charCodeAt(0); code += 1) {
+                const drive = `${String.fromCharCode(code)}:\\`;
+                candidates.add(path.join(drive, "Steam"));
+                candidates.add(path.join(drive, "SteamLibrary"));
+            }
+        } else if (process.platform === "linux") {
+            candidates.add(path.join(app.getPath("home"), ".local", "share", "Steam"));
+            candidates.add(path.join(app.getPath("home"), ".steam", "steam"));
+        }
+
+        const existing = await Promise.all(Array.from(candidates).map(async candidate => {
+            return (await pathExists(path.join(candidate, "steamapps")).catch(() => false)) ? candidate : null;
+        }));
+
+        return existing.filter(Boolean);
+    }
+
+    private async getGameFolderFallback(gameId: string, gameFolder?: string): Promise<string> {
+        if (!gameFolder) {
+            return null;
+        }
+
+        const roots = await this.getSteamRootCandidates();
+
+        for (const root of roots) {
+            const appManifest = path.join(root, "steamapps", `appmanifest_${gameId}.acf`);
+            const appFolder = path.join(root, "steamapps", "common", gameFolder);
+
+            if (
+                await pathExists(appFolder).catch(() => false)
+                || await pathExists(`${appFolder}.bak`).catch(() => false)
+                || await pathExists(appManifest).catch(() => false)
+            ) {
+                log.info("Resolved Steam game folder from fallback", { gameId, gameFolder, appFolder });
+                return appFolder;
+            }
+        }
+
+        log.warn("Unable to resolve Steam game folder", { gameId, gameFolder, roots });
+        return null;
+    }
+
     public async getGameFolder(gameId: string, gameFolder?: string): Promise<string> {
         try {
             const steamPath = await this.getSteamPath();
@@ -103,17 +177,17 @@ export class SteamService {
             let libraryFolders: any = path.join(steamPath, "steamapps", "libraryfolders.vdf");
 
             if (!(await pathExists(libraryFolders))) {
-                return null;
+                return this.getGameFolderFallback(gameId, gameFolder);
             }
 
             libraryFolders = parse(await readFile(libraryFolders, { encoding: "utf-8" }));
 
             if (!libraryFolders.libraryfolders) {
-                return null;
+                return this.getGameFolderFallback(gameId, gameFolder);
             }
             libraryFolders = libraryFolders.libraryfolders;
 
-            for (const libKey in Object.keys(libraryFolders)) {
+            for (const libKey of Object.keys(libraryFolders)) {
                 if (!libraryFolders?.[libKey]?.apps) {
                     continue;
                 }
@@ -124,10 +198,23 @@ export class SteamService {
                 }
             }
 
-            return null;
+            if (gameFolder) {
+                for (const libKey of Object.keys(libraryFolders)) {
+                    if (!libraryFolders?.[libKey]?.path) {
+                        continue;
+                    }
+
+                    const appFolder = path.join(libraryFolders[libKey].path, "steamapps", "common", gameFolder);
+                    if (await pathExists(appFolder) || await pathExists(`${appFolder}.bak`)) {
+                        return appFolder;
+                    }
+                }
+            }
+
+            return this.getGameFolderFallback(gameId, gameFolder);
         } catch (e) {
             log.error(e);
-            return null;
+            return this.getGameFolderFallback(gameId, gameFolder);
         }
     }
 


### PR DESCRIPTION
⚠️ AI Disclosure

Steam appears to hold the SteamVR folder now on launch on occasion, preventing the rename system from working. Additionally, it causes a hang in BSManager as it attempts and fails to rename the folder.

## Scope

Updating the behavior of FPFC mode to prevent SteamVR launch without requiring the user to rename the folder.

## Implementation

This removes the SteamVR folder/file rename guard from the FPFC launch path. The previous flow attempted to temporarily rename the SteamVR installation directory so Beat Saber could not initialize SteamVR. That approach can block when Steam or SteamVR has an open handle on the folder, which makes the Launch button appear stuck before Beat Saber starts.

FPFC launch now relies on process-local launch configuration instead:

- Adds `-vrmode None` when FPFC mode is enabled and Oculus mode is not selected.
- Sets `XR_RUNTIME_JSON` to a non-existent per-instance path for the Beat Saber process, preventing the OpenXR loader from resolving the system SteamVR runtime for this launch.
- Keeps the Steam readiness fallback that treats a running `steam.exe` process as sufficient even when Steam's `ActiveUser` registry value is unavailable.
- Keeps launch step logging so future hangs show the exact launch phase and elapsed time.
- Detaches from the Beat Saber process shortly after spawn so the Launch button does not remain busy until the game exits.

Tradeoff: this no longer modifies or restores the SteamVR installation on disk. That avoids the file-lock hang entirely, but means SteamVR prevention depends on launch args/environment instead of physically hiding SteamVR.

## How to Test

- Install or run the updated BSManager build.
- Ensure Steam is already running.
- Ensure SteamVR is installed. Optionally start SteamVR first to verify BSManager no longer attempts to rename or restore the SteamVR folder.
- Open a Steam Beat Saber instance in BSManager.
- Enable FPFC mode.
- Enable Debug mode if you want to verify launch args/logging.
- Click Launch.
- Confirm the Launch button clears shortly after launch instead of waiting on SteamVR folder operations.
- Check the BSManager log and confirm there are no SteamVR rename/restore steps.
- Confirm the launch command includes FPFC behavior, including `-vrmode None` and `fpfc`.
- Confirm the log includes `Overriding OpenXR runtime for FPFC launch`.

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> Nice refactor!

> Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | ❌             | RED                                 |
| Non-blocking | 🤔             | Yellow, thinking, etc               |
| Praise       | ✅             | Green, hearts, positive emojis, etc |
