### PR TITLE
add right-click context menu on nav bar versions

### DIFF
--- a/src/renderer/components/modal/modal-types/uninstall-modal.component.tsx
+++ b/src/renderer/components/modal/modal-types/uninstall-modal.component.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from "renderer/hooks/use-translation.hook";
 
 export const UninstallModal: ModalComponent<void, BSVersion> = ({ resolver, options: {data} }) => {
     const version = data;
+    const versionLabel = version.name ? `${version.name} (${version.BSVersion})` : version.BSVersion;
     const t = useTranslation();
 
     return (
@@ -18,7 +19,7 @@ export const UninstallModal: ModalComponent<void, BSVersion> = ({ resolver, opti
         >
             <h1 className="text-3xl uppercase tracking-wide w-full text-center text-gray-800 dark:text-gray-200">{t("modals.bs-uninstall.title")}</h1>
             <BsmImage className="mx-auto h-24" image={BeatConflict} />
-            <p className="max-w-sm text-gray-800 dark:text-gray-200">{t("modals.bs-uninstall.description", { version: version.BSVersion })}</p>
+            <p className="max-w-sm text-gray-800 dark:text-gray-200">{t("modals.bs-uninstall.description", { version: versionLabel })}</p>
             <div className="grid grid-flow-col grid-cols-2 gap-4 mt-4">
                 <BsmButton
                     typeColor="cancel"

--- a/src/renderer/components/nav-bar/nav-bar-items/bs-version-item.component.tsx
+++ b/src/renderer/components/nav-bar/nav-bar-items/bs-version-item.component.tsx
@@ -1,12 +1,14 @@
 import { BSVersion } from "shared/bs-version.interface";
 import { Link, useLocation } from "react-router-dom";
-import { useState } from "react";
-import { distinctUntilChanged, lastValueFrom, map, of, Subscription, switchMap, take } from "rxjs";
+import { MouseEventHandler, useEffect, useMemo, useState } from "react";
+import { distinctUntilChanged, lastValueFrom, map, of, Subject, Subscription, switchMap, take } from "rxjs";
 import { BSLauncherService } from "renderer/services/bs-launcher.service";
 import { ConfigurationService } from "renderer/services/configuration.service";
+import { IpcService } from "renderer/services/ipc.service";
 import { BSUninstallerService } from "renderer/services/bs-uninstaller.service";
 import { BSVersionManagerService } from "renderer/services/bs-version-manager.service";
-import { BsmIcon } from "../../svgs/bsm-icon.component";
+import { ModalExitCode, ModalService } from "renderer/services/modale.service";
+import { BsmIcon, BsmIconType } from "../../svgs/bsm-icon.component";
 import { useThemeColor } from "renderer/hooks/use-theme-color.hook";
 import { NavBarItem } from "./nav-bar-item.component";
 import useFitText from "use-fit-text";
@@ -17,6 +19,22 @@ import { useOnUpdate } from "renderer/hooks/use-on-update.hook";
 import { BsDownloaderService } from "renderer/services/bs-version-download/bs-downloader.service";
 import { ProgressBarService } from "renderer/services/progress-bar.service";
 import { noop } from "shared/helpers/function.helpers";
+import { NotificationService } from "renderer/services/notification.service";
+import { CustomError } from "shared/models/exceptions/custom-error.class";
+import { ShareFoldersModal } from "renderer/components/modal/modal-types/share-folders-modal.component";
+import { UninstallModal } from "renderer/components/modal/modal-types/uninstall-modal.component";
+import { CreateLaunchShortcutModal } from "renderer/components/modal/modal-types/create-launch-shortcut-modal.component";
+import { useTranslation } from "renderer/hooks/use-translation.hook";
+
+type VersionContextMenuItem = {
+    text: string;
+    icon?: BsmIconType;
+    onClick: () => void | Promise<void>;
+};
+
+// Emits the id of the version item whose context menu just opened, so every
+// other item can close its own menu (only one context menu open at a time).
+const contextMenuOpened$ = new Subject<string>();
 
 export function BsVersionItem(props: { version: BSVersion }) {
 
@@ -26,6 +44,10 @@ export function BsVersionItem(props: { version: BSVersion }) {
     const configService = useService(ConfigurationService);
     const bsUninstallerService = useService(BSUninstallerService);
     const progressBar = useService(ProgressBarService);
+    const ipcService = useService(IpcService);
+    const modalService = useService(ModalService);
+    const notification = useService(NotificationService);
+    const t = useTranslation();
 
     const { state } = useLocation() as { state: BSVersion };
     const { fontSize, ref } = useFitText();
@@ -33,6 +55,9 @@ export function BsVersionItem(props: { version: BSVersion }) {
     const [isDownloading, setIsDownloading] = useState(false);
     const [downloadProgress, setDownloadProgress] = useState(0);
     const secondColor = useThemeColor("second-color");
+
+    const itemId = useMemo(() => JSON.stringify(props.version), [props.version]);
+    const [menuVisible, setMenuVisible] = useState(false);
 
     useOnUpdate(() => {
         const subs: Subscription[] = []
@@ -51,6 +76,15 @@ export function BsVersionItem(props: { version: BSVersion }) {
 
         return () => subs.forEach(sub => sub.unsubscribe());
     }, [props.version]);
+
+    useEffect(() => {
+        const sub = contextMenuOpened$.subscribe(openedId => {
+            if (openedId !== itemId) {
+                setMenuVisible(false);
+            }
+        });
+        return () => sub.unsubscribe();
+    }, [itemId]);
 
     const isActive = (): boolean => {
         return props.version?.BSVersion === state?.BSVersion && props?.version.steam === state?.steam && props?.version.oculus === state?.oculus && props?.version.name === state?.name;
@@ -103,21 +137,136 @@ export function BsVersionItem(props: { version: BSVersion }) {
         );
     };
 
+    const openFolder = () => lastValueFrom(ipcService.sendV2("bs-version.open-folder", props.version)).catch(noop);
+    const verifyFiles = () => bsDownloader.verifyBsVersion(props.version).then(() => {}).catch(noop);
+
+    const openContextMenu: MouseEventHandler<HTMLElement> = e => {
+        if (isDownloading) {
+            return;
+        }
+        e.preventDefault();
+        e.stopPropagation();
+        contextMenuOpened$.next(itemId);
+        setMenuVisible(true);
+    };
+
+    const menuItems: VersionContextMenuItem[] = [
+        { text: "pages.version-viewer.dropdown.open-folder", icon: "folder", onClick: openFolder },
+        { text: "pages.version-viewer.dropdown.verify-files", icon: "task", onClick: verifyFiles },
+        ...(!props.version.steam && !props.version.oculus ? [{
+            text: "pages.version-viewer.dropdown.edit",
+            icon: "edit" as const,
+            onClick: () => verionManagerService.editVersion(props.version).then(() => {}),
+        }] : []),
+        ...(!props.version.oculus ? [{
+            text: "pages.version-viewer.dropdown.clone",
+            icon: "copy" as const,
+            onClick: () => verionManagerService.cloneVersion(props.version).then(() => {}),
+        }] : []),
+        {
+            text: "pages.version-viewer.dropdown.shared-folders",
+            icon: "link",
+            onClick: () => modalService.openModal(ShareFoldersModal, { data: props.version }).then(() => {}),
+        },
+        {
+            text: "pages.version-viewer.dropdown.create-shortcut",
+            icon: "shortcut",
+            onClick: async () => {
+                const res = await modalService.openModal(CreateLaunchShortcutModal, { data: props.version });
+                if (res.exitCode !== ModalExitCode.COMPLETED) {
+                    return;
+                }
+
+                return lastValueFrom(launcherService.createLaunchShortcut(res.data.launchOption, res.data.steamShortcut)).then(() => {
+                    return notification.notifySuccess({
+                        title: "notifications.create-launch-shortcut.success.title",
+                        desc: `notifications.create-launch-shortcut.success.${res.data.steamShortcut ? "msg-steam" : "msg"}`
+                    }).then(() => {});
+                }).catch(() => {
+                    return notification.notifyError({
+                        title: "notifications.types.error",
+                        desc: "notifications.create-launch-shortcut.error.msg"
+                    }).then(() => {});
+                });
+            }
+        },
+        ...(!props.version.steam && !props.version.oculus ? [{
+            text: "pages.version-viewer.dropdown.uninstall",
+            icon: "trash" as const,
+            onClick: async () => {
+                const modalRes = await modalService.openModal(UninstallModal, { data: props.version });
+                if (modalRes.exitCode !== ModalExitCode.COMPLETED) {
+                    return;
+                }
+
+                return bsUninstallerService.uninstall(props.version).then(() => {
+                    return verionManagerService.askInstalledVersions().then(() => {});
+                }).catch((err: CustomError) => {
+                    let desc = err?.message;
+
+                    if (["CantDeleteOfficialVersion", "VersionNotFound"].includes(err?.code)) {
+                        desc = `notifications.bs-uninstall.errors.desc.${err.code}`;
+                    } else if (err?.code?.startsWith("generic.fs.delete-folder")) {
+                        desc = "notifications.bs-uninstall.errors.desc.delete-folder";
+                    }
+
+                    return notification.notifyError({ title: "notifications.bs-uninstall.errors.title", desc }).then(() => {});
+                });
+            }
+        }] : []),
+    ];
+
+    const menuContent = (
+        <ul className="py-1 min-w-[200px] text-sm cursor-pointer">
+            {menuItems.map(item => (
+                <li key={item.text}>
+                    <button
+                        type="button"
+                        onClick={() => {
+                            setMenuVisible(false);
+                            Promise.resolve(item.onClick()).catch(noop);
+                        }}
+                        className="flex w-full items-center px-3 py-2 text-left hover:backdrop-brightness-125"
+                    >
+                        {item.icon && <BsmIcon icon={item.icon} className="h-5 w-5 mr-2 text-inherit shrink-0" />}
+                        <span className="whitespace-nowrap">{t(item.text)}</span>
+                    </button>
+                </li>
+            ))}
+        </ul>
+    );
+
     return (
         <NavBarItem onCancel={cancel} progress={downloadProgress} isActive={isActive() && !isDownloading} isDownloading={isDownloading}>
-            {props.version.name ? (
-                <Tippy content={props.version.BSVersion} placement="right-end" arrow={false} className="font-bold !bg-neutral-900" duration={[100, 0]} animation="shift-away-subtle">
-                    <Link onDoubleClick={handleDoubleClick} to={`/bs-version/${props.version.BSVersion}`} state={props.version} className="w-full flex items-center justify-start content-center max-w-full">
-                        {renderIcon()}
-                        {renderVersionText()}
-                    </Link>
-                </Tippy>
-            ) : (
-                <Link onDoubleClick={handleDoubleClick} to={`/bs-version/${props.version.BSVersion}`} state={props.version} className="w-full flex items-center justify-start content-center max-w-full">
-                    {renderIcon()}
-                    {renderVersionText()}
-                </Link>
-            )}
+            <Tippy
+                visible={menuVisible}
+                onClickOutside={() => setMenuVisible(false)}
+                interactive
+                placement="right-start"
+                arrow
+                appendTo={() => document.body}
+                theme="version-context-menu"
+                animation="shift-away-subtle"
+                duration={[100, 0]}
+                offset={[0, 12]}
+                content={menuContent}
+            >
+                <div className="w-full flex items-center justify-start" onContextMenu={openContextMenu}>
+                    {props.version.name ? (
+                        <Tippy content={props.version.BSVersion} placement="right-end" arrow={false} className="font-bold !bg-neutral-900" duration={[100, 0]} animation="shift-away-subtle" disabled={menuVisible}>
+                            <Link onDoubleClick={handleDoubleClick} to={`/bs-version/${props.version.BSVersion}`} state={props.version} className="w-full flex items-center justify-start content-center max-w-full">
+                                {renderIcon()}
+                                {renderVersionText()}
+                            </Link>
+                        </Tippy>
+                    ) : (
+                        <Link onDoubleClick={handleDoubleClick} to={`/bs-version/${props.version.BSVersion}`} state={props.version} className="w-full flex items-center justify-start content-center max-w-full">
+                            {renderIcon()}
+                            {renderVersionText()}
+                        </Link>
+                    )}
+                </div>
+            </Tippy>
         </NavBarItem>
     );
 }

--- a/src/renderer/components/nav-bar/nav-bar-items/bs-version-item.component.tsx
+++ b/src/renderer/components/nav-bar/nav-bar-items/bs-version-item.component.tsx
@@ -1,5 +1,5 @@
 import { BSVersion } from "shared/bs-version.interface";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import { MouseEventHandler, useEffect, useMemo, useState } from "react";
 import { distinctUntilChanged, lastValueFrom, map, of, Subject, Subscription, switchMap, take } from "rxjs";
 import { BSLauncherService } from "renderer/services/bs-launcher.service";
@@ -48,6 +48,7 @@ export function BsVersionItem(props: { version: BSVersion }) {
     const modalService = useService(ModalService);
     const notification = useService(NotificationService);
     const t = useTranslation();
+    const navigate = useNavigate();
 
     const { state } = useLocation() as { state: BSVersion };
     const { fontSize, ref } = useFitText();
@@ -88,6 +89,14 @@ export function BsVersionItem(props: { version: BSVersion }) {
 
     const isActive = (): boolean => {
         return props.version?.BSVersion === state?.BSVersion && props?.version.steam === state?.steam && props?.version.oculus === state?.oculus && props?.version.name === state?.name;
+    };
+
+    const navigateToVersion = (version?: BSVersion) => {
+        if (!version) {
+            return navigate("/available-versions");
+        }
+
+        navigate(`/bs-version/${version.BSVersion}`, { state: version });
     };
 
     const handleDoubleClick = async () => {
@@ -141,11 +150,13 @@ export function BsVersionItem(props: { version: BSVersion }) {
     const verifyFiles = () => bsDownloader.verifyBsVersion(props.version).then(() => {}).catch(noop);
 
     const openContextMenu: MouseEventHandler<HTMLElement> = e => {
-        if (isDownloading) {
-            return;
-        }
         e.preventDefault();
         e.stopPropagation();
+
+        if (isDownloading || bsDownloader.downloadingVersion || bsDownloader.isVerifying || !progressBar.require()) {
+            return;
+        }
+
         contextMenuOpened$.next(itemId);
         setMenuVisible(true);
     };
@@ -156,12 +167,20 @@ export function BsVersionItem(props: { version: BSVersion }) {
         ...(!props.version.steam && !props.version.oculus ? [{
             text: "pages.version-viewer.dropdown.edit",
             icon: "edit" as const,
-            onClick: () => verionManagerService.editVersion(props.version).then(() => {}),
+            onClick: () => verionManagerService.editVersion(props.version).then(newVersion => {
+                if (newVersion) {
+                    navigateToVersion(newVersion);
+                }
+            }),
         }] : []),
         ...(!props.version.oculus ? [{
             text: "pages.version-viewer.dropdown.clone",
             icon: "copy" as const,
-            onClick: () => verionManagerService.cloneVersion(props.version).then(() => {}),
+            onClick: () => verionManagerService.cloneVersion(props.version).then(newVersion => {
+                if (newVersion) {
+                    navigateToVersion(newVersion);
+                }
+            }),
         }] : []),
         {
             text: "pages.version-viewer.dropdown.shared-folders",
@@ -199,8 +218,14 @@ export function BsVersionItem(props: { version: BSVersion }) {
                     return;
                 }
 
+                const wasActive = isActive();
+
                 return bsUninstallerService.uninstall(props.version).then(() => {
-                    return verionManagerService.askInstalledVersions().then(() => {});
+                    return verionManagerService.askInstalledVersions().then(versions => {
+                        if (wasActive) {
+                            navigateToVersion(versions?.at(0));
+                        }
+                    });
                 }).catch((err: CustomError) => {
                     let desc = err?.message;
 

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -114,6 +114,27 @@
     @apply border-r-neutral-900;
 }
 
+.tippy-box[data-theme~='version-context-menu'] {
+    @apply bg-light-main-color-2 dark:bg-main-color-2;
+    @apply text-gray-800 dark:text-gray-200;
+    @apply rounded-md shadow-md shadow-black;
+}
+.tippy-box[data-theme~='version-context-menu'] > .tippy-content {
+    padding: 0;
+}
+.tippy-box[data-theme~='version-context-menu'][data-placement^='left'] > .tippy-arrow::before {
+    @apply border-l-light-main-color-2 dark:border-l-main-color-2;
+}
+.tippy-box[data-theme~='version-context-menu'][data-placement^='right'] > .tippy-arrow::before {
+    @apply border-r-light-main-color-2 dark:border-r-main-color-2;
+}
+.tippy-box[data-theme~='version-context-menu'][data-placement^='top'] > .tippy-arrow::before {
+    @apply border-t-light-main-color-2 dark:border-t-main-color-2;
+}
+.tippy-box[data-theme~='version-context-menu'][data-placement^='bottom'] > .tippy-arrow::before {
+    @apply border-b-light-main-color-2 dark:border-b-main-color-2;
+}
+
 .tippy-box[data-theme~='red'] {
     @apply bg-neutral-900;
     @apply text-red-400;


### PR DESCRIPTION
## Scope

Add a right-click menu on version items in the nav bar to quickly access version actions without opening the version page.

[closes #116](https://github.com/Zagrios/bs-manager/issues/116)

## Implementation

- Added a context menu on `bs-version-item.component.tsx` using `onContextMenu`.
- Reused existing version actions (open folder, verify, edit, clone, shared folders, shortcut, uninstall).
- Used Tippy.js with arrow and body portal so the menu is not clipped by the nav bar.
- Ensured only one context menu can be open at a time.
- Added a dedicated menu theme in `index.css` (`version-context-menu`) for consistent styling.

## Screenshots

| before | after |
| ------ | ----- |
|  | <img width="401" height="266" alt="{E599F654-239E-4D46-B7DD-0BA5B2F16E63}" src="https://github.com/user-attachments/assets/9284257b-8273-4957-8ad0-a3e5f296b7f5" /> |


## How to Test

- Right-click a version in the nav bar.
- Confirm the menu opens correctly and is not cut off.
- Check actions behave like the version page gear menu.
- Right-click another version and confirm the previous menu closes.
- Confirm conditional items:
  - No edit/uninstall for Steam/Oculus versions
  - No clone for Oculus versions

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

> 🟢 Nice refactor!  
> 🟡 Why was the default value removed?  
> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |