### PR TITLE
Change npm install to npm ci for dependency installation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Hello! We’re delighted that you’re interested in contributing to **BSManager
    ```
 3. **Install project dependencies**:
    ```bash
-   npm install
+   npm ci
    ```
 
 ### Create a Dedicated Branch


### PR DESCRIPTION
I think it's better to use this command instead of `npm i` so you don't have to keep modifying `package-lock.json`.

source : https://docs.npmjs.com/cli/v8/commands/npm-ci