### PR TITLE
Isolate remote auth windows

### DIFF
--- a/src/__tests__/unit/window-manager.service.test.ts
+++ b/src/__tests__/unit/window-manager.service.test.ts
@@ -24,12 +24,14 @@ jest.mock("main/services/utils.service", () => ({
 }));
 
 describe("WindowManagerService", () => {
+    const windowManager = WindowManagerService.getInstance();
+
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
     it("provides enough vertical space for launch confirmation modals", async () => {
-        await WindowManagerService.getInstance().openWindow("shortcut-launch.html");
+        await windowManager.openWindow("shortcut-launch.html");
 
         expect(BrowserWindow).toHaveBeenCalledWith(expect.objectContaining({
             width: 600,
@@ -41,7 +43,7 @@ describe("WindowManagerService", () => {
     });
 
     it("keeps the privileged preload for internal application windows", async () => {
-        await WindowManagerService.getInstance().openWindow("index.html");
+        await windowManager.openWindow("index.html");
 
         expect(BrowserWindow).toHaveBeenCalledWith(expect.objectContaining({
             webPreferences: expect.objectContaining({
@@ -51,7 +53,7 @@ describe("WindowManagerService", () => {
     });
 
     it("opens remote windows without a preload and with hardened preferences", async () => {
-        await WindowManagerService.getInstance().openRemoteWindow("https://secure.oculus.com", {
+        await windowManager.openRemoteWindow("https://secure.oculus.com", {
             webPreferences: {
                 preload: "untrusted-preload.js",
                 nodeIntegration: true,
@@ -62,9 +64,9 @@ describe("WindowManagerService", () => {
             },
         });
 
-        const options = (BrowserWindow as unknown as jest.Mock).mock.calls[0][0];
-        expect(options.webPreferences).not.toHaveProperty("preload");
-        expect(options.webPreferences).toEqual(expect.objectContaining({
+        const { webPreferences } = (BrowserWindow as unknown as jest.Mock).mock.calls[0][0];
+        expect(webPreferences).not.toHaveProperty("preload");
+        expect(webPreferences).toEqual(expect.objectContaining({
             nodeIntegration: false,
             nodeIntegrationInWorker: false,
             nodeIntegrationInSubFrames: false,
@@ -77,14 +79,14 @@ describe("WindowManagerService", () => {
     });
 
     it("rejects remote URLs passed to the privileged internal-window API", async () => {
-        await expect(WindowManagerService.getInstance().openWindow("https://example.com"))
+        await expect(windowManager.openWindow("https://example.com"))
             .rejects.toThrow("Remote URLs must be opened with openRemoteWindow");
 
         expect(BrowserWindow).not.toHaveBeenCalled();
     });
 
     it("blocks an internal window from navigating to a remote page", async () => {
-        await WindowManagerService.getInstance().openWindow("index.html");
+        await windowManager.openWindow("index.html");
 
         const navigationHandler = mockWindow.webContents.on.mock.calls
             .find(([event]) => event === "will-navigate")?.[1];

--- a/src/__tests__/unit/window-manager.service.test.ts
+++ b/src/__tests__/unit/window-manager.service.test.ts
@@ -4,6 +4,7 @@ import { WindowManagerService } from "main/services/window-manager.service";
 const mockWindow = {
     webContents: {
         setWindowOpenHandler: jest.fn(),
+        on: jest.fn(),
         getURL: jest.fn(() => ""),
     },
     removeMenu: jest.fn(),
@@ -22,7 +23,11 @@ jest.mock("main/services/utils.service", () => ({
     UtilsService: { getInstance: jest.fn(() => ({ getBuildPath: jest.fn((path: string) => path) })) },
 }));
 
-describe("WindowManagerService shortcut launch window", () => {
+describe("WindowManagerService", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
     it("provides enough vertical space for launch confirmation modals", async () => {
         await WindowManagerService.getInstance().openWindow("shortcut-launch.html");
 
@@ -33,5 +38,59 @@ describe("WindowManagerService shortcut launch window", () => {
             minHeight: 300,
             resizable: true,
         }));
+    });
+
+    it("keeps the privileged preload for internal application windows", async () => {
+        await WindowManagerService.getInstance().openWindow("index.html");
+
+        expect(BrowserWindow).toHaveBeenCalledWith(expect.objectContaining({
+            webPreferences: expect.objectContaining({
+                preload: expect.stringContaining("preload.js"),
+            }),
+        }));
+    });
+
+    it("opens remote windows without a preload and with hardened preferences", async () => {
+        await WindowManagerService.getInstance().openRemoteWindow("https://secure.oculus.com", {
+            webPreferences: {
+                preload: "untrusted-preload.js",
+                nodeIntegration: true,
+                contextIsolation: false,
+                sandbox: false,
+                webSecurity: false,
+                webviewTag: true,
+            },
+        });
+
+        const options = (BrowserWindow as unknown as jest.Mock).mock.calls[0][0];
+        expect(options.webPreferences).not.toHaveProperty("preload");
+        expect(options.webPreferences).toEqual(expect.objectContaining({
+            nodeIntegration: false,
+            nodeIntegrationInWorker: false,
+            nodeIntegrationInSubFrames: false,
+            contextIsolation: true,
+            sandbox: true,
+            webSecurity: true,
+            allowRunningInsecureContent: false,
+            webviewTag: false,
+        }));
+    });
+
+    it("rejects remote URLs passed to the privileged internal-window API", async () => {
+        await expect(WindowManagerService.getInstance().openWindow("https://example.com"))
+            .rejects.toThrow("Remote URLs must be opened with openRemoteWindow");
+
+        expect(BrowserWindow).not.toHaveBeenCalled();
+    });
+
+    it("blocks an internal window from navigating to a remote page", async () => {
+        await WindowManagerService.getInstance().openWindow("index.html");
+
+        const navigationHandler = mockWindow.webContents.on.mock.calls
+            .find(([event]) => event === "will-navigate")?.[1];
+        const event = { preventDefault: jest.fn() };
+        navigationHandler(event, "https://example.com");
+
+        expect(event.preventDefault).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/main/services/bs-version-download/bs-oculus-downloader.service.ts
+++ b/src/main/services/bs-version-download/bs-oculus-downloader.service.ts
@@ -41,7 +41,7 @@ export class BsOculusDownloaderService {
 
         const loginUrl = "https://secure.oculus.com";
         const redirectUrl = `${loginUrl}/my/profile`;
-        const window = await this.windows.openWindow(loginUrl, { frame: true, width: 650, height: 800 });
+        const window = await this.windows.openRemoteWindow(loginUrl, { frame: true, width: 650, height: 800 });
 
         let timout: NodeJS.Timeout;
 

--- a/src/main/services/window-manager.service.ts
+++ b/src/main/services/window-manager.service.ts
@@ -4,7 +4,6 @@ import { UtilsService } from "./utils.service";
 import { AppWindow } from "shared/models/window-manager/app-window.model";
 import path from "path";
 import { APP_NAME } from "../constants";
-import { isValidUrl } from "../../shared/helpers/url.helpers";
 
 export class WindowManagerService {
     private static instance: WindowManagerService;
@@ -43,20 +42,54 @@ export class WindowManagerService {
 
     private constructor() {}
 
-    private handleNewWindow(url: AppWindow, window: BrowserWindow){
+    private isHttpUrl(url: string, httpsOnly = false): boolean {
+        try {
+            const { protocol } = new URL(url);
+            return protocol === "https:" || (!httpsOnly && protocol === "http:");
+        } catch {
+            return false;
+        }
+    }
+
+    private isAbsoluteUrl(url: string): boolean {
+        try {
+            new URL(url);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    private handleNewWindow(url: string, window: BrowserWindow, isInternal: boolean){
 
         window.webContents.setWindowOpenHandler(({ url }) => {
-            if(isValidUrl(url)){
+            if(this.isHttpUrl(url)){
                 shell.openExternal(url);
             }
 
             return { action: "deny"}
         });
 
+        const handleNavigation = (event: { preventDefault: () => void }, navigationUrl: string) => {
+            const isAllowed = isInternal
+                ? navigationUrl.startsWith(resolveHtmlPath(""))
+                : this.isHttpUrl(navigationUrl, true);
+
+            if(isAllowed){ return; }
+
+            event.preventDefault();
+            if(this.isHttpUrl(navigationUrl)){
+                shell.openExternal(navigationUrl);
+            }
+        };
+
+        window.webContents.on("will-navigate", handleNavigation);
+        window.webContents.on("will-redirect", handleNavigation);
+
         window.removeMenu();
         window.setMenu(null);
 
-        const promise = window.loadURL(isValidUrl(url) ? url : resolveHtmlPath(url));
+        const promise = window.loadURL(url);
 
         window.once("ready-to-show", () => {
             if (!window) {
@@ -69,9 +102,49 @@ export class WindowManagerService {
     }
 
     public openWindow(url: AppWindow, options?: BrowserWindowConstructorOptions): Promise<BrowserWindow> {
+        if(this.isAbsoluteUrl(url)){
+            return Promise.reject(new Error("Remote URLs must be opened with openRemoteWindow"));
+        }
+
         const windowType = url.split("?")[0];
-        const window = new BrowserWindow({ ...(this.appWindowsOptions[windowType] ?? {}), ...this.baseWindowOption, ...options });
-        return this.handleNewWindow(url, window);
+        const window = new BrowserWindow({
+            ...(this.appWindowsOptions[windowType] ?? {}),
+            ...this.baseWindowOption,
+            ...options,
+            webPreferences: {
+                ...this.baseWindowOption.webPreferences,
+                ...options?.webPreferences,
+                preload: this.PRELOAD_PATH,
+            },
+        });
+        return this.handleNewWindow(resolveHtmlPath(url), window, true);
+    }
+
+    public openRemoteWindow(url: string, options?: BrowserWindowConstructorOptions): Promise<BrowserWindow> {
+        if(!this.isHttpUrl(url, true)){
+            return Promise.reject(new Error("Remote windows only support HTTPS URLs"));
+        }
+
+        const webPreferences = { ...options?.webPreferences };
+        delete webPreferences.preload;
+
+        const window = new BrowserWindow({
+            ...this.baseWindowOption,
+            ...options,
+            webPreferences: {
+                ...webPreferences,
+                nodeIntegration: false,
+                nodeIntegrationInWorker: false,
+                nodeIntegrationInSubFrames: false,
+                contextIsolation: true,
+                sandbox: true,
+                webSecurity: true,
+                allowRunningInsecureContent: false,
+                webviewTag: false,
+            },
+        });
+
+        return this.handleNewWindow(url, window, false);
     }
 
     public closeAllWindows(except?: AppWindow) {

--- a/src/main/services/window-manager.service.ts
+++ b/src/main/services/window-manager.service.ts
@@ -4,6 +4,7 @@ import { UtilsService } from "./utils.service";
 import { AppWindow } from "shared/models/window-manager/app-window.model";
 import path from "path";
 import { APP_NAME } from "../constants";
+import { isValidUrl } from "../../shared/helpers/url.helpers";
 
 export class WindowManagerService {
     private static instance: WindowManagerService;
@@ -51,36 +52,28 @@ export class WindowManagerService {
         }
     }
 
-    private isAbsoluteUrl(url: string): boolean {
-        try {
-            new URL(url);
-            return true;
-        } catch {
-            return false;
+    private openExternalHttpUrl(url: string): void {
+        if(this.isHttpUrl(url)){
+            shell.openExternal(url);
         }
     }
 
-    private handleNewWindow(url: string, window: BrowserWindow, isInternal: boolean){
+    private handleNewWindow(
+        initialUrl: string,
+        window: BrowserWindow,
+        isNavigationAllowed: (url: string) => boolean
+    ){
 
-        window.webContents.setWindowOpenHandler(({ url }) => {
-            if(this.isHttpUrl(url)){
-                shell.openExternal(url);
-            }
-
+        window.webContents.setWindowOpenHandler(({ url: targetUrl }) => {
+            this.openExternalHttpUrl(targetUrl);
             return { action: "deny"}
         });
 
         const handleNavigation = (event: { preventDefault: () => void }, navigationUrl: string) => {
-            const isAllowed = isInternal
-                ? navigationUrl.startsWith(resolveHtmlPath(""))
-                : this.isHttpUrl(navigationUrl, true);
-
-            if(isAllowed){ return; }
+            if(isNavigationAllowed(navigationUrl)){ return; }
 
             event.preventDefault();
-            if(this.isHttpUrl(navigationUrl)){
-                shell.openExternal(navigationUrl);
-            }
+            this.openExternalHttpUrl(navigationUrl);
         };
 
         window.webContents.on("will-navigate", handleNavigation);
@@ -89,7 +82,7 @@ export class WindowManagerService {
         window.removeMenu();
         window.setMenu(null);
 
-        const promise = window.loadURL(url);
+        const promise = window.loadURL(initialUrl);
 
         window.once("ready-to-show", () => {
             if (!window) {
@@ -102,7 +95,7 @@ export class WindowManagerService {
     }
 
     public openWindow(url: AppWindow, options?: BrowserWindowConstructorOptions): Promise<BrowserWindow> {
-        if(this.isAbsoluteUrl(url)){
+        if(isValidUrl(url)){
             return Promise.reject(new Error("Remote URLs must be opened with openRemoteWindow"));
         }
 
@@ -117,7 +110,7 @@ export class WindowManagerService {
                 preload: this.PRELOAD_PATH,
             },
         });
-        return this.handleNewWindow(resolveHtmlPath(url), window, true);
+        return this.handleNewWindow(resolveHtmlPath(url), window, navigationUrl => navigationUrl.startsWith(resolveHtmlPath("")));
     }
 
     public openRemoteWindow(url: string, options?: BrowserWindowConstructorOptions): Promise<BrowserWindow> {
@@ -144,7 +137,7 @@ export class WindowManagerService {
             },
         });
 
-        return this.handleNewWindow(url, window, false);
+        return this.handleNewWindow(url, window, navigationUrl => this.isHttpUrl(navigationUrl, true));
     }
 
     public closeAllWindows(except?: AppWindow) {

--- a/src/main/services/window-manager.service.ts
+++ b/src/main/services/window-manager.service.ts
@@ -101,7 +101,7 @@ export class WindowManagerService {
 
         const windowType = url.split("?")[0];
         const window = new BrowserWindow({
-            ...(this.appWindowsOptions[windowType] ?? {}),
+            ...this.appWindowsOptions[windowType],
             ...this.baseWindowOption,
             ...options,
             webPreferences: {


### PR DESCRIPTION
Opens Meta/Oculus authentication in a sandboxed HTTPS-only window without the privileged preload, while preventing privileged app windows from navigating to remote content. Adds regression tests for this security boundary.

Validation: production build, targeted ESLint, and 114 unit tests passed (5 skipped).