### PR TITLE
Update electron-builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -107,7 +107,7 @@
                 "css-minimizer-webpack-plugin": "^8.0.0",
                 "detect-port": "^2.1.0",
                 "electron": "^39.8.10",
-                "electron-builder": "^26.15.3",
+                "electron-builder": "^26.15.6",
                 "electron-devtools-installer": "^4.0.0",
                 "electronmon": "^2.0.4",
                 "eslint": "^8.56.0",
@@ -7059,9 +7059,9 @@
             }
         },
         "node_modules/app-builder-lib": {
-            "version": "26.15.3",
-            "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.15.3.tgz",
-            "integrity": "sha512-2VnyWkqsP5v5XbBhL3tD5Syx8iNPBYsoU7kY4S2fz7wg8Rj/nztWKCUzGKaFRTv0Xwf3/H058CR1Kvtd/3lRow==",
+            "version": "26.15.6",
+            "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.15.6.tgz",
+            "integrity": "sha512-lN6BliNJLnS2ruBdYd1j1rzd2yl4ZwKqyTtAwVznIkkadOR9cFvRz/tNQ6nd824AobnFZKhcdFrpIGDnr0PRSg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7111,8 +7111,8 @@
                 "node": ">=14.0.0"
             },
             "peerDependencies": {
-                "dmg-builder": "26.15.3",
-                "electron-builder-squirrel-windows": "26.15.3"
+                "dmg-builder": "26.15.6",
+                "electron-builder-squirrel-windows": "26.15.6"
             }
         },
         "node_modules/app-builder-lib/node_modules/@electron/get": {
@@ -10291,13 +10291,13 @@
             "license": "MIT"
         },
         "node_modules/dmg-builder": {
-            "version": "26.15.3",
-            "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.15.3.tgz",
-            "integrity": "sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==",
+            "version": "26.15.6",
+            "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.15.6.tgz",
+            "integrity": "sha512-nr5vQxEhM0REomp1qiHbc6V99yrfBZy+wUU56VXADfSOlLj8PdLqsHiRe7b+FbqKesiyv4ax+k1GVwGonYKuCg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "app-builder-lib": "26.15.3",
+                "app-builder-lib": "26.15.6",
                 "builder-util": "26.15.3",
                 "fs-extra": "^10.1.0",
                 "js-yaml": "^4.1.0"
@@ -10606,18 +10606,18 @@
             }
         },
         "node_modules/electron-builder": {
-            "version": "26.15.3",
-            "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.15.3.tgz",
-            "integrity": "sha512-a1KM5heqS3gQCZzizXEI8RjJy3QVogULPdeSknt76uLDpBIW/HDGsMg/XgP0riP6PI9COsRvFITKKGDqA8fJxA==",
+            "version": "26.15.6",
+            "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.15.6.tgz",
+            "integrity": "sha512-jxlHRjqYrlTgLVo/aoACGpiki3QFYv8s4f2djsqaEbwTBZ9PcTBK03Tj/HMa65kiE0hdZxxbZdmVFo22eou2wA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "app-builder-lib": "26.15.3",
+                "app-builder-lib": "26.15.6",
                 "builder-util": "26.15.3",
                 "builder-util-runtime": "9.7.0",
                 "chalk": "^4.1.2",
                 "ci-info": "^4.2.0",
-                "dmg-builder": "26.15.3",
+                "dmg-builder": "26.15.6",
                 "fs-extra": "^10.1.0",
                 "lazy-val": "^1.0.5",
                 "simple-update-notifier": "2.0.0",
@@ -10632,15 +10632,15 @@
             }
         },
         "node_modules/electron-builder-squirrel-windows": {
-            "version": "26.15.3",
-            "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.15.3.tgz",
-            "integrity": "sha512-Jc19XPV9y9+2bAdZPkXuVNGNIEFBq9poHC61l8Kv6FdK7DRG3+Ic0rerC0DXOaeHNz8yW0fg/JnF8GQROOF5MA==",
+            "version": "26.15.6",
+            "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.15.6.tgz",
+            "integrity": "sha512-Vgw0bVXtTjZmD3O0Wl1gbo4eiI0Mqp7FQBsFgMR+wNwySiPJ08jadS0PZiSwP2cKCVaEclBHbKeBVTwil+SJfQ==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "app-builder-lib": "26.15.3",
-                "builder-util": "26.15.3",
+                "app-builder-lib": "26.15.6",
+                "builder-util": "26.15.6",
                 "electron-winstaller": "5.4.0"
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10640,7 +10640,7 @@
             "peer": true,
             "dependencies": {
                 "app-builder-lib": "26.15.6",
-                "builder-util": "26.15.6",
+                "builder-util": "26.15.3",
                 "electron-winstaller": "5.4.0"
             }
         },

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
         "css-minimizer-webpack-plugin": "^8.0.0",
         "detect-port": "^2.1.0",
         "electron": "^39.8.10",
-        "electron-builder": "^26.15.3",
+        "electron-builder": "^26.15.6",
         "electron-devtools-installer": "^4.0.0",
         "electronmon": "^2.0.4",
         "eslint": "^8.56.0",


### PR DESCRIPTION
<!--

Please use the content below as a template for your pull request.
Feel free to remove sections which do not make sense.

-->

## Scope

<!-- Brief description of WHAT you’re doing and WHY. -->
Closes #1075 

## Implementation

After recent updates, the AUR build results in:
```
Error [ERR_REQUIRE_ESM]: require() of ES Module /home/liam/.cache/yay/bs-manager-git/src/bs-manager/node_modules/@noble/hashes/blake2.js from /home/liam/.cache/yay/bs-manager-git/src/bs-manager/node_modules/app-builder-lib/out/targets/blockmap/blockmap.js not supported.
Instead change the require of blake2.js in /home/liam/.cache/yay/bs-manager-git/src/bs-manager/node_modules/app-builder-lib/out/targets/blockmap/blockmap.js to a dynamic import() which is available in all CommonJS modules.
```

Locking @noble/hashes: 1.4.0 (the previous blake2.js) did not work so tried updating electron-builder instead which fixed the issue and allows the build to complete successfully.



## Screenshots

N/A

## How to Test

Used tests outlined in CONTRIBUTING:

npm run build
npm test -- --runInBand
npm run lint
npm audit --omit=dev
npx electron-builder --config electron-builder.config.js --publish never --linux pacman --x64


npm test -- --runInBand gives 22/23, possible local difference so will see what the github CI says:

```Summary of all failing tests
 FAIL  src/__tests__/unit/oculus-launcher.service.test.ts
  ● Test suite failed to run

    Electron failed to install correctly, please delete node_modules/electron and try installing again

       8 | import { BS_EXECUTABLE, IS_FLATPAK } from "main/constants";
       9 | import { LaunchMods } from "shared/models/bs-launch/launch-option.interface";
    > 10 | import { app } from "electron";
         | ^
      11 | import { StaticConfigurationService } from "main/services/static-configuration.service";
      12 | import { abortableDelay } from "main/helpers/abortable-delay.helper";
      13 | import { randomUUID } from "node:crypto";

      at getElectronPath (node_modules/electron/index.js:17:11)
      at Object.<anonymous> (node_modules/electron/index.js:21:18)
      at Object.<anonymous> (src/main/services/bs-launcher/abstract-launcher.service.ts:10:1)
      at Object.<anonymous> (src/main/services/bs-launcher/oculus-launcher.service.ts:9:1)
      at Object.<anonymous> (src/__tests__/unit/oculus-launcher.service.test.ts:4:1)


Test Suites: 1 failed, 22 passed, 23 total
Tests:       186 passed, 186 total
Snapshots:   0 total
Time:        2.934 s, estimated 3 s
Ran all test suites.
```


## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don’t block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
