### PR TITLE
feat: download versions on card double-click

### DIFF
--- a/src/__tests__/unit/available-version-item.test.ts
+++ b/src/__tests__/unit/available-version-item.test.ts
@@ -1,0 +1,112 @@
+import React from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import type { BSVersion } from "shared/bs-version.interface";
+
+jest.mock("dateformat", () => jest.fn(() => "formatted date"));
+jest.mock("framer-motion", () => ({ motion: { li: "li" } }));
+jest.mock("renderer/components/shared/bsm-image.component", () => ({
+    BsmImage: () => null,
+}));
+jest.mock("renderer/components/shared/glow-effect.component", () => ({
+    GlowEffect: () => null,
+}));
+jest.mock("renderer/components/svgs/icons/steam-icon.component", () => ({
+    SteamIcon: () => null,
+}));
+jest.mock("renderer/hooks/use-translation.hook", () => ({
+    useTranslation: () => (key: string) => key,
+}));
+jest.mock("renderer/hooks/use-constant.hook", () => ({
+    useConstant: (factory: () => unknown) => factory(),
+}));
+jest.mock("renderer/components/shared/bsm-button.component", () => {
+    const ReactModule = jest.requireActual("react") as typeof import("react");
+
+    return {
+        BsmButton: ({ onClick, disabled, title }: any) => ReactModule.createElement("button", { onClick, disabled, title }),
+    };
+});
+jest.mock("renderer/pages/available-versions-list.components", () => {
+    const ReactModule = jest.requireActual("react") as typeof import("react");
+
+    return {
+        AvailableVersionsContext: ReactModule.createContext(null),
+    };
+});
+
+const { AvailableVersionsContext } = require(
+    "renderer/pages/available-versions-list.components"
+) as typeof import("renderer/pages/available-versions-list.components");
+
+const { AvailableVersionItem } = require(
+    "renderer/components/available-versions/available-version-item.component"
+) as typeof import("renderer/components/available-versions/available-version-item.component");
+
+const version: BSVersion = {
+    BSVersion: "1.44.2",
+    ReleaseDate: "1710000000",
+    ReleaseURL: "https://steamcommunity.com/example",
+};
+
+function renderItem(downloading = false) {
+    const startDownload = jest.fn();
+    let renderer!: TestRenderer.ReactTestRenderer;
+
+    act(() => {
+        renderer = TestRenderer.create(
+            React.createElement(
+                AvailableVersionsContext.Provider,
+                { value: { startDownload, downloading } },
+                React.createElement(AvailableVersionItem, { version })
+            )
+        );
+    });
+
+    return { renderer, startDownload };
+}
+
+describe("AvailableVersionItem download interactions", () => {
+    it("starts the existing download flow when the card is double-clicked", () => {
+        const { renderer, startDownload } = renderItem();
+
+        act(() => renderer.root.findByType("li").props.onDoubleClick());
+
+        expect(startDownload).toHaveBeenCalledTimes(1);
+        expect(startDownload).toHaveBeenCalledWith(version);
+        act(() => renderer.unmount());
+    });
+
+    it("isolates the Steam link and download button from the card double-click", () => {
+        const { renderer, startDownload } = renderItem();
+        const actions = renderer.root.findAllByType("div").find(node => node.props.className === "flex flex-row items-center gap-1.5");
+        const link = renderer.root.findByType("a");
+        const clickStop = jest.fn();
+        const doubleClickStop = jest.fn();
+
+        act(() => link.props.onClick({ stopPropagation: clickStop }));
+        act(() => actions!.props.onDoubleClick({ stopPropagation: doubleClickStop }));
+
+        expect(clickStop).toHaveBeenCalledTimes(1);
+        expect(doubleClickStop).toHaveBeenCalledTimes(1);
+        expect(startDownload).not.toHaveBeenCalled();
+        act(() => renderer.unmount());
+    });
+
+    it("keeps the existing download button behavior and disabled state", () => {
+        const { renderer, startDownload } = renderItem();
+        const button = renderer.root.findByType("button");
+        const stopPropagation = jest.fn();
+
+        act(() => button.props.onClick({ stopPropagation }));
+
+        expect(stopPropagation).toHaveBeenCalledTimes(1);
+        expect(startDownload).toHaveBeenCalledTimes(1);
+        expect(startDownload).toHaveBeenCalledWith(version);
+        expect(button.props.disabled).toBe(false);
+        act(() => renderer.unmount());
+
+        const disabledItem = renderItem(true);
+        expect(disabledItem.renderer.root.findByType("button").props.disabled).toBe(true);
+        act(() => disabledItem.renderer.unmount());
+    });
+});

--- a/src/renderer/components/available-versions/available-version-item.component.tsx
+++ b/src/renderer/components/available-versions/available-version-item.component.tsx
@@ -37,9 +37,9 @@ export const AvailableVersionItem = memo(function AvailableVersionItem({version}
                         <h2 className="block text-xl font-bold text-white tracking-wider">{version.BSVersion}</h2>
                         <span className="text-sm text-gray-700 dark:text-gray-400">{formatedDate}</span>
                     </div>
-                    <div className="flex flex-row items-center gap-1.5">
+                    <div className="flex flex-row items-center gap-1.5" onDoubleClick={e => e.stopPropagation()}>
                         {version.ReleaseURL && (
-                            <a href={version.ReleaseURL} target="_blank" onClick={e => e.stopPropagation()} onDoubleClick={e => e.stopPropagation()} className="flex flex-row justify-between items-center rounded-full bg-black bg-opacity-30 text-white pb-px overflow-hidden hover:bg-opacity-50" tabIndex={-1}>
+                            <a href={version.ReleaseURL} target="_blank" onClick={e => e.stopPropagation()} className="flex flex-row justify-between items-center rounded-full bg-black bg-opacity-30 text-white pb-px overflow-hidden hover:bg-opacity-50" tabIndex={-1}>
                                 <SteamIcon className="w-[25px] h-[25px] transition-transform group-hover/card:rotate-[-360deg] duration-300" />
                                 <span className="relative -left-px text-sm w-fit max-w-0 text-center overflow-hidden h-full whitespace-nowrap pb-[3px] transition-all group-hover/card:max-w-[200px] group-hover/card:px-1 duration-300">{t("pages.available-versions.steam-release")}</span>
                             </a>

--- a/src/renderer/components/available-versions/available-version-item.component.tsx
+++ b/src/renderer/components/available-versions/available-version-item.component.tsx
@@ -24,7 +24,7 @@ export const AvailableVersionItem = memo(function AvailableVersionItem({version}
     const formatedDate = useConstant(() => dateFormat(+version.ReleaseDate * 1000, "ddd. d mmm yyyy"));
 
     return (
-        <motion.li className="group/card relative w-72 h-60" onHoverStart={() => setHovered(true)} onHoverEnd={() => setHovered(false)}>
+        <motion.li className="group/card relative w-72 h-60 cursor-pointer" onDoubleClick={() => context?.startDownload(version)} onHoverStart={() => setHovered(true)} onHoverEnd={() => setHovered(false)}>
             <GlowEffect visible={hovered} className="absolute" />
             <div className="relative flex flex-col overflow-hidden rounded-md w-72 h-60 shadow-lg shadow-gray-900 group-hover/card:shadow-none duration-300 bg-light-main-color-2 dark:bg-main-color-2">
                 {version.recommended && (
@@ -39,7 +39,7 @@ export const AvailableVersionItem = memo(function AvailableVersionItem({version}
                     </div>
                     <div className="flex flex-row items-center gap-1.5">
                         {version.ReleaseURL && (
-                            <a href={version.ReleaseURL} target="_blank" onClick={e => e.stopPropagation()} className="flex flex-row justify-between items-center rounded-full bg-black bg-opacity-30 text-white pb-px overflow-hidden hover:bg-opacity-50" tabIndex={-1}>
+                            <a href={version.ReleaseURL} target="_blank" onClick={e => e.stopPropagation()} onDoubleClick={e => e.stopPropagation()} className="flex flex-row justify-between items-center rounded-full bg-black bg-opacity-30 text-white pb-px overflow-hidden hover:bg-opacity-50" tabIndex={-1}>
                                 <SteamIcon className="w-[25px] h-[25px] transition-transform group-hover/card:rotate-[-360deg] duration-300" />
                                 <span className="relative -left-px text-sm w-fit max-w-0 text-center overflow-hidden h-full whitespace-nowrap pb-[3px] transition-all group-hover/card:max-w-[200px] group-hover/card:px-1 duration-300">{t("pages.available-versions.steam-release")}</span>
                             </a>


### PR DESCRIPTION
## Scope

Allow users to start downloading a Beat Saber version by double-clicking its card in the available versions interface.

This improves the download experience and aligns version cards with similar interactions already available elsewhere in BSManager.

## Implementation

- Added a double-click handler to version cards.
- Reused the existing `startDownload` flow, preserving:
  - outdated-version confirmation;
  - concurrent-download protection;
  - the existing Steam/Oculus download logic.
- Added a pointer cursor to indicate that cards are interactive.
- Prevented double-clicks on the Steam release link from also triggering a version download.

## How to Test

1. Open the available versions interface.
2. Double-click a version card.
3. Verify that the normal version download flow starts.
4. Double-click the Steam release link and verify that it opens without starting a download.
5. Verify that the existing download button still works.
6. Try starting another download while one is already pending and verify that no duplicate download starts.

## Validation

- `npm run lint`
- `npm run build`
- `git diff --check`

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

> 🟢 Praise or minor suggestions

> 🟡 Clarifying questions or non-blocking feedback

> 🔴 Blocking feedback that must be addressed

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc.              |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc. |