### PR TITLE
Korean translation Fix 

### DIFF
--- a/assets/jsons/translations/ko.json
+++ b/assets/jsons/translations/ko.json
@@ -583,12 +583,12 @@
             },
             "warnings": {
                 "titles": {
-                    "FPFC_NEED_ADMIN": "FPFC mode setup incomplete",
-                    "UNABLE_TO_LAUNCH_STEAM": "Could not launch Steam"
+                    "FPFC_NEED_ADMIN": "FPFC 모드 설정 미완료",
+                    "UNABLE_TO_LAUNCH_STEAM": "Steam을 실행할 수 없음"
                 },
                 "msg": {
-                    "FPFC_NEED_ADMIN": "BSManager needs administrator privileges to properly set up FPFC mode. Run BSManager as administrator for the best experience.",
-                    "UNABLE_TO_LAUNCH_STEAM": "Steam could not be started automatically."
+                    "FPFC_NEED_ADMIN": "FPFC 모드를 올바르게 설정하려면 BSManager에 관리자 권한이 필요합니다. 최상의 환경을 위해 BSManager를 관리자 권한으로 실행하세요.",
+                    "UNABLE_TO_LAUNCH_STEAM": "Steam을 자동으로 실행할 수 없었습니다."
                 }
             }
         },

--- a/assets/jsons/translations/ko.json
+++ b/assets/jsons/translations/ko.json
@@ -1062,7 +1062,8 @@
             "tags": "태그",
             "specificities": "특성",
             "requirements": "모드 필요",
-            "exclude": "제외하기"
+            "exclude": "제외하기",
+            "leaderboard": "리더보드"
         },
         "map-types": {
             "accuracy": "정확도",
@@ -1113,10 +1114,15 @@
         },
         "map-specificities": {
             "automapper": "오토매핑",
-            "ranked": "랭크",
             "curated": "선별됨",
             "verified": "인증됨",
             "fullSpread": "풀 스프레드"
+        },
+        "map-leaderboard": {
+            "All": "전체",
+            "Ranked": "랭크",
+            "BeatLeader": "BeatLeader",
+            "ScoreSaber": "ScoreSaber"
         },
         "map-excludes": {
             "installed": "설치됨"
@@ -1204,7 +1210,7 @@
                 },
                 "no-models": "모델을 찾을 수 없습니다.",
                 "no-internet": "인터넷에 연결할 수 없습니다.",
-                "error-occured": "오류가 발생했습니다. 다시 시도해 주세요."
+                "error-occurred": "오류가 발생했습니다. 다시 시도해 주세요."
             }
         },
         "notifications": {


### PR DESCRIPTION
## Scope

Fills two gaps where `ko.json` had fallen behind `en.json`.

Adds the missing Korean (`ko.json`) translations for the map leaderboard filter, which was
introduced in the map filter panel but never localized. In Korean the leaderboard section header
and its dropdown options were falling back to raw translation keys.

Also translates the `bs-launch` warning notifications, which were present in `ko.json` but still
held the English source strings, and removes one dead key plus a key-name mismatch against
`en.json`.

## Implementation

**Missing keys (were rendering as raw keys in Korean)**

- `maps.map-filter-panel.leaderboard`: added as "리더보드" (= leaderboard).
- `maps.map-leaderboard.*`: added the whole block, matching the `MapLeaderboard`
- `All` → "전체" 
- `Ranked` → "랭크" (= ranked)

**Untranslated strings (keys existed, but the values were still English)**

- `warnings.titles.FPFC_NEED_ADMIN` → "FPFC 모드 설정 미완료" (= FPFC mode setup incomplete)
- `warnings.titles.UNABLE_TO_LAUNCH_STEAM` → "Steam을 실행할 수 없음" (= could not launch Steam)
- `warnings.msg.FPFC_NEED_ADMIN` → "FPFC 모드를 올바르게 설정하려면 BSManager에 관리자 권한이 필요합니다.
  최상의 환경을 위해 BSManager를 관리자 권한으로 실행하세요."
- `warnings.msg.UNABLE_TO_LAUNCH_STEAM` → "Steam을 자동으로 실행할 수 없었습니다."

**Dead key removal**

- Removed `maps.map-specificities.ranked`. The `MapSpecificity` enum only contains

**Key name mismatch**

- `models.modals.download-models.error-occured` → `error-occurred`, to match `en.json`. The Korean
  string itself is unchanged.

## Emoji Guide

**For reviewers: Emojis can be added to comments to call out blocking versus non-blocking feedback.**

E.g: Praise, minor suggestions, or clarifying questions that don't block merging the PR.

> 🟢 Nice refactor!

> 🟡 Why was the default value removed?

E.g: Blocking feedback must be addressed before merging.

> 🔴 This change will break something important

|              |                |                                     |
| ------------ | -------------- | ----------------------------------- |
| Blocking     | 🔴 ❌ 🚨       | RED                                 |
| Non-blocking | 🟡 💡 🤔 💭    | Yellow, thinking, etc               |
| Praise       | 🟢 💚 😍 👍 🙌 | Green, hearts, positive emojis, etc |
