### PR TITLE
Fix offline version loading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -95,6 +95,7 @@
                 "@types/use-double-click": "^1.0.4",
                 "@types/webpack-bundle-analyzer": "^4.4.2",
                 "@types/webpack-env": "^1.18.0",
+                "@types/yauzl": "^3.4.0",
                 "@typescript-eslint/eslint-plugin": "^6.20.0",
                 "@typescript-eslint/parser": "^6.20.0",
                 "autoprefixer": "^10.4.17",
@@ -5760,6 +5761,16 @@
             "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/yauzl": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-3.4.0.tgz",
+            "integrity": "sha512-NRPn5w6h8dhcnmx3YIRQcqMywY/+nND/uOkJessedcrowO3C0AssHp3tMJpxKAwOhFOo0OV1y9VtsC5hbKKBAw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
         "@types/use-double-click": "^1.0.4",
         "@types/webpack-bundle-analyzer": "^4.4.2",
         "@types/webpack-env": "^1.18.0",
+        "@types/yauzl": "^3.4.0",
         "@typescript-eslint/eslint-plugin": "^6.20.0",
         "@typescript-eslint/parser": "^6.20.0",
         "autoprefixer": "^10.4.17",

--- a/src/__tests__/unit/bs-local-version.service.test.ts
+++ b/src/__tests__/unit/bs-local-version.service.test.ts
@@ -1,0 +1,70 @@
+import { mkdtemp, rm, writeFile } from "fs/promises";
+import os from "os";
+import path from "path";
+import { BSLocalVersionService } from "main/services/bs-local-version.service";
+import { BSVersion } from "shared/bs-version.interface";
+
+jest.mock("electron", () => ({
+    app: { getPath: jest.fn(() => "") },
+}));
+jest.mock("electron-log", () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() }));
+jest.mock("main/services/bs-version-lib.service", () => ({
+    BSVersionLibService: { getInstance: jest.fn(() => ({})) },
+}));
+jest.mock("main/services/installation-location.service", () => ({
+    InstallationLocationService: { getInstance: jest.fn(() => ({})) },
+}));
+jest.mock("main/services/steam.service", () => ({
+    SteamService: { getInstance: jest.fn(() => ({})) },
+}));
+jest.mock("main/services/oculus.service", () => ({
+    OculusService: { getInstance: jest.fn(() => ({})) },
+}));
+jest.mock("main/services/configuration.service", () => ({
+    ConfigurationService: { getInstance: jest.fn(() => ({})) },
+}));
+jest.mock("main/services/folder-linker.service", () => ({
+    FolderLinkerService: { getInstance: jest.fn(() => ({})) },
+}));
+jest.mock("main/services/static-configuration.service", () => ({
+    StaticConfigurationService: { getInstance: jest.fn(() => ({})) },
+}));
+
+type BSLocalVersionServiceInternals = {
+    versionLibService: {
+        getCachedVersions: jest.Mock<Promise<BSVersion[]>, []>;
+    };
+    getVersionFromGlobalGameManagerFile(versionFilePath: string): Promise<BSVersion>;
+};
+
+describe("BSLocalVersionService local version detection", () => {
+    let tempDirectory: string;
+
+    beforeEach(async () => {
+        tempDirectory = await mkdtemp(path.join(os.tmpdir(), "bs-manager-version-detection-"));
+    });
+
+    afterEach(async () => {
+        await rm(tempDirectory, { recursive: true, force: true });
+    });
+
+    it("checks recent versions first without mutating the shared cached catalog", async () => {
+        const versionFilePath = path.join(tempDirectory, "globalgamemanagers");
+        await writeFile(versionFilePath, "metadata 1.2.10 metadata\n", "utf-8");
+
+        const cachedVersions = [
+            { BSVersion: "1.2" },
+            { BSVersion: "1.2.10" },
+        ] as BSVersion[];
+        Object.freeze(cachedVersions);
+
+        const service = Object.create(BSLocalVersionService.prototype) as BSLocalVersionService;
+        const internals = service as unknown as BSLocalVersionServiceInternals;
+        internals.versionLibService = {
+            getCachedVersions: jest.fn().mockResolvedValue(cachedVersions),
+        };
+
+        await expect(internals.getVersionFromGlobalGameManagerFile(versionFilePath)).resolves.toEqual(cachedVersions[1]);
+        expect(cachedVersions.map(version => version.BSVersion)).toEqual(["1.2", "1.2.10"]);
+    });
+});

--- a/src/__tests__/unit/bs-version-lib.service.test.ts
+++ b/src/__tests__/unit/bs-version-lib.service.test.ts
@@ -1,0 +1,247 @@
+import { Observable, lastValueFrom, toArray } from "rxjs";
+import { BSVersionLibService } from "main/services/bs-version-lib.service";
+import { BSVersion } from "shared/bs-version.interface";
+
+jest.mock("electron-log", () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() }));
+jest.mock("main/services/utils.service", () => ({
+    UtilsService: { getInstance: jest.fn(() => ({ getAssestsJsonsPath: jest.fn(() => "C:/assets") })) },
+}));
+jest.mock("main/services/request.service", () => ({
+    RequestService: { getInstance: jest.fn(() => ({ getJSON: jest.fn() })) },
+}));
+jest.mock("main/services/static-configuration.service", () => ({
+    StaticConfigurationService: { getInstance: jest.fn(() => ({ get: jest.fn(), set: jest.fn() })) },
+}));
+
+type Deferred<T> = {
+    promise: Promise<T>;
+    resolve: (value: T) => void;
+    reject: (reason?: unknown) => void;
+};
+
+type JSONResponse = {
+    data: unknown;
+    headers: Record<string, string>;
+};
+
+type BSVersionLibInternals = {
+    REMOTE_BS_VERSIONS_TIMEOUT: number;
+    cachedVersions: BSVersion[] | null;
+    loadPromise: Promise<BSVersion[]> | null;
+    refreshPromise: Promise<BSVersion[] | null> | null;
+    requestService: {
+        getJSON: jest.Mock;
+    };
+    getLocalVersions: () => Promise<unknown>;
+    updateLocalVersions: (versions: BSVersion[]) => Promise<void>;
+};
+
+const LOCAL_VERSIONS: BSVersion[] = [
+    { BSVersion: "1.40.8", ReleaseDate: "2025-04-10" },
+];
+
+const REMOTE_VERSIONS: BSVersion[] = [
+    { BSVersion: "1.40.8", ReleaseDate: "2025-04-10" },
+    { BSVersion: "1.41.0", ReleaseDate: "2025-05-08" },
+];
+
+function deferred<T>(): Deferred<T> {
+    let resolveDeferred: Deferred<T>["resolve"];
+    let rejectDeferred: Deferred<T>["reject"];
+    const promise = new Promise<T>((resolve, reject) => {
+        resolveDeferred = resolve;
+        rejectDeferred = reject;
+    });
+
+    return { promise, resolve: resolveDeferred, reject: rejectDeferred };
+}
+
+function nextEventLoopTurn(): Promise<void> {
+    return new Promise(resolve => {
+        setImmediate(resolve);
+    });
+}
+
+function collect<T>(stream: Observable<T>): Promise<T[]> {
+    return lastValueFrom(stream.pipe(toArray()));
+}
+
+function createHarness(
+    localResult: unknown | Promise<unknown> = LOCAL_VERSIONS,
+    remoteRequest: jest.Mock = jest.fn().mockResolvedValue({ data: REMOTE_VERSIONS, headers: {} })
+) {
+    (BSVersionLibService as any).instance = undefined;
+    const service = BSVersionLibService.getInstance();
+    const internals = service as unknown as BSVersionLibInternals;
+    const getLocalVersions = jest.spyOn(internals, "getLocalVersions").mockReturnValue(Promise.resolve(localResult));
+    const updateLocalVersions = jest.spyOn(internals, "updateLocalVersions").mockResolvedValue(undefined);
+    internals.requestService = { getJSON: remoteRequest };
+
+    return { service, internals, getLocalVersions, updateLocalVersions, remoteRequest };
+}
+
+describe("BSVersionLibService cache-first refresh", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (BSVersionLibService as any).instance = undefined;
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        (BSVersionLibService as any).instance = undefined;
+    });
+
+    it("loads the cached catalog without starting a remote request", async () => {
+        const { service, getLocalVersions, updateLocalVersions, remoteRequest } = createHarness();
+
+        await expect(collect(service.getAvailableVersions$())).resolves.toEqual([LOCAL_VERSIONS]);
+        await expect(service.getCachedVersions()).resolves.toBe(LOCAL_VERSIONS);
+        expect(getLocalVersions).toHaveBeenCalledTimes(1);
+        expect(remoteRequest).not.toHaveBeenCalled();
+        expect(updateLocalVersions).not.toHaveBeenCalled();
+    });
+
+    it("normalizes an invalid local catalog without starting a remote request", async () => {
+        const { service, updateLocalVersions, remoteRequest } = createHarness([{ ReleaseDate: "2025-04-10" }]);
+
+        await expect(collect(service.getAvailableVersions$())).resolves.toEqual([[]]);
+        await expect(service.getCachedVersions()).resolves.toEqual([]);
+        expect(remoteRequest).not.toHaveBeenCalled();
+        expect(updateLocalVersions).not.toHaveBeenCalled();
+    });
+
+    it("emits the local catalog before the next event-loop turn when the remote request never settles", async () => {
+        const remoteRequest = jest.fn(() => new Promise<JSONResponse>(() => {
+            // Intentionally left pending to reproduce the stalled network request.
+        }));
+        const { service, getLocalVersions, updateLocalVersions } = createHarness(LOCAL_VERSIONS, remoteRequest);
+        const timeout = jest.spyOn(global, "setTimeout").mockImplementation((() => 0) as unknown as typeof setTimeout);
+        const emissions: BSVersion[][] = [];
+        let completed = false;
+        let streamError: unknown;
+
+        const subscription = service.getAvailableVersions$(true).subscribe({
+            next: versions => emissions.push(versions),
+            error: error => { streamError = error; },
+            complete: () => { completed = true; },
+        });
+
+        try {
+            await nextEventLoopTurn();
+
+            expect(emissions).toEqual([LOCAL_VERSIONS]);
+            expect(completed).toBe(false);
+            expect(streamError).toBeUndefined();
+            expect(getLocalVersions).toHaveBeenCalledTimes(1);
+            expect(remoteRequest).toHaveBeenCalledTimes(1);
+            expect(remoteRequest).toHaveBeenCalledWith(
+                expect.any(String),
+                { signal: expect.any(AbortSignal), retryLimit: 0 }
+            );
+            expect(updateLocalVersions).not.toHaveBeenCalled();
+        } finally {
+            subscription.unsubscribe();
+            timeout.mockRestore();
+        }
+    });
+
+    it("emits a successful remote refresh, updates memory, and persists it", async () => {
+        const remote = deferred<JSONResponse>();
+        const remoteRequest = jest.fn(() => remote.promise);
+        const { service, getLocalVersions, updateLocalVersions } = createHarness(LOCAL_VERSIONS, remoteRequest);
+        const emissionsPromise = collect(service.getAvailableVersions$(true));
+
+        await nextEventLoopTurn();
+        remote.resolve({ data: REMOTE_VERSIONS, headers: {} });
+
+        await expect(emissionsPromise).resolves.toEqual([LOCAL_VERSIONS, REMOTE_VERSIONS]);
+        await expect(service.getCachedVersions()).resolves.toBe(REMOTE_VERSIONS);
+        expect(getLocalVersions).toHaveBeenCalledTimes(1);
+        expect(remoteRequest).toHaveBeenCalledTimes(1);
+        expect(updateLocalVersions).toHaveBeenCalledTimes(1);
+        expect(updateLocalVersions).toHaveBeenCalledWith(REMOTE_VERSIONS);
+    });
+
+    it("deduplicates concurrent streams, the local read, and the remote request", async () => {
+        const local = deferred<BSVersion[]>();
+        const remote = deferred<JSONResponse>();
+        const remoteRequest = jest.fn(() => remote.promise);
+        const { service, getLocalVersions, updateLocalVersions } = createHarness(local.promise, remoteRequest);
+
+        const firstStream = collect(service.getAvailableVersions$(true));
+        const secondStream = collect(service.getAvailableVersions$(true));
+
+        expect(getLocalVersions).toHaveBeenCalledTimes(1);
+        expect(remoteRequest).not.toHaveBeenCalled();
+
+        local.resolve(LOCAL_VERSIONS);
+        await nextEventLoopTurn();
+
+        expect(remoteRequest).toHaveBeenCalledTimes(1);
+        remote.resolve({ data: REMOTE_VERSIONS, headers: {} });
+
+        await expect(Promise.all([firstStream, secondStream])).resolves.toEqual([
+            [LOCAL_VERSIONS, REMOTE_VERSIONS],
+            [LOCAL_VERSIONS, REMOTE_VERSIONS],
+        ]);
+        expect(getLocalVersions).toHaveBeenCalledTimes(1);
+        expect(remoteRequest).toHaveBeenCalledTimes(1);
+        expect(updateLocalVersions).toHaveBeenCalledTimes(1);
+    });
+
+    it("recovers from a local read failure with a valid remote catalog", async () => {
+        const localError = Promise.reject<unknown>(new Error("corrupted local catalog"));
+        const { service, getLocalVersions, updateLocalVersions, remoteRequest } = createHarness(localError);
+
+        await expect(collect(service.getAvailableVersions$(true))).resolves.toEqual([
+            [],
+            REMOTE_VERSIONS,
+        ]);
+        await expect(service.getCachedVersions()).resolves.toBe(REMOTE_VERSIONS);
+        expect(getLocalVersions).toHaveBeenCalledTimes(1);
+        expect(remoteRequest).toHaveBeenCalledTimes(1);
+        expect(updateLocalVersions).toHaveBeenCalledWith(REMOTE_VERSIONS);
+    });
+
+    it.each([
+        ["a network error", () => Promise.reject(new Error("offline"))],
+        ["an empty remote catalog", () => Promise.resolve({ data: [], headers: {} })],
+        ["an invalid remote catalog", () => Promise.resolve({ data: [{}], headers: {} })],
+        ["an unchanged remote catalog", () => Promise.resolve({ data: LOCAL_VERSIONS.map(version => ({ ...version })), headers: {} })],
+    ])("keeps only the local emission without persistence after %s", async (_label, request) => {
+        const remoteRequest = jest.fn(request);
+        const { service, updateLocalVersions } = createHarness(LOCAL_VERSIONS, remoteRequest);
+
+        await expect(collect(service.getAvailableVersions$(true))).resolves.toEqual([LOCAL_VERSIONS]);
+        await expect(service.getCachedVersions()).resolves.toBe(LOCAL_VERSIONS);
+        expect(updateLocalVersions).not.toHaveBeenCalled();
+    });
+
+    it("aborts a timed-out refresh, then completes with only the local catalog", async () => {
+        const remoteRequest = jest.fn((_url: string, options: { signal: AbortSignal }) => (
+            new Promise<JSONResponse>((_resolve, reject) => {
+                options.signal.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+            })
+        ));
+        const { service, internals, updateLocalVersions } = createHarness(LOCAL_VERSIONS, remoteRequest);
+        internals.REMOTE_BS_VERSIONS_TIMEOUT = 0;
+
+        await expect(collect(service.getAvailableVersions$(true))).resolves.toEqual([LOCAL_VERSIONS]);
+        expect(remoteRequest.mock.calls[0][1].signal.aborted).toBe(true);
+        expect(updateLocalVersions).not.toHaveBeenCalled();
+    });
+
+    it("keeps the remote emission and memory cache when persistence fails", async () => {
+        const remoteRequest = jest.fn().mockResolvedValue({ data: REMOTE_VERSIONS, headers: {} });
+        const { service, updateLocalVersions } = createHarness(LOCAL_VERSIONS, remoteRequest);
+        updateLocalVersions.mockRejectedValue(new Error("read-only installation"));
+
+        await expect(collect(service.getAvailableVersions$(true))).resolves.toEqual([
+            LOCAL_VERSIONS,
+            REMOTE_VERSIONS,
+        ]);
+        await expect(service.getCachedVersions()).resolves.toBe(REMOTE_VERSIONS);
+        expect(updateLocalVersions).toHaveBeenCalledTimes(1);
+        expect(updateLocalVersions).toHaveBeenCalledWith(REMOTE_VERSIONS);
+    });
+});

--- a/src/__tests__/unit/renderer-bs-version-manager.service.test.ts
+++ b/src/__tests__/unit/renderer-bs-version-manager.service.test.ts
@@ -1,0 +1,278 @@
+import { BehaviorSubject, Observable, Subject, of } from "rxjs";
+import { BSVersionManagerService } from "renderer/services/bs-version-manager.service";
+import { BSVersion } from "shared/bs-version.interface";
+
+jest.mock("renderer", () => ({ logRenderError: jest.fn() }));
+jest.mock("renderer/services/ipc.service", () => ({ IpcService: { getInstance: jest.fn() } }));
+jest.mock("renderer/services/modale.service", () => ({
+    ModalExitCode: { COMPLETED: 0, CANCELED: 2 },
+    ModalService: { getInstance: jest.fn() },
+}));
+jest.mock("renderer/services/notification.service", () => ({ NotificationService: { getInstance: jest.fn() } }));
+jest.mock("renderer/services/progress-bar.service", () => ({ ProgressBarService: { getInstance: jest.fn() } }));
+jest.mock("renderer/components/modal/modal-types/edit-version-modal.component", () => ({ EditVersionModal: jest.fn() }));
+jest.mock("renderer/components/modal/modal-types/import-version-modal.component", () => ({ ImportVersionModal: jest.fn() }));
+
+type VersionManagerInternals = {
+    ipcService: { sendV2: jest.Mock<Observable<BSVersion[]>, [string, unknown?]> };
+    availableVersionsRefreshPromise: Promise<BSVersion[]> | null;
+    installedVersionsRequestPromise: Promise<BSVersion[]> | null;
+    installedVersionsRescanQueued: boolean;
+    installedVersions$: BehaviorSubject<BSVersion[]>;
+    availableVersions$: BehaviorSubject<BSVersion[]>;
+};
+
+const LOCAL_VERSIONS: BSVersion[] = [
+    { BSVersion: "1.40.8", ReleaseDate: "2025-04-10" },
+];
+
+const METADATA_UPDATED_VERSIONS: BSVersion[] = [
+    { BSVersion: "1.40.8", ReleaseDate: "2025-04-11", recommended: true },
+];
+
+const REMOTE_VERSIONS: BSVersion[] = [
+    ...LOCAL_VERSIONS,
+    { BSVersion: "1.41.0", ReleaseDate: "2025-05-08" },
+];
+
+function createService(sendV2: jest.Mock): BSVersionManagerService {
+    const service = Object.create(BSVersionManagerService.prototype) as BSVersionManagerService;
+    Object.assign(service as unknown as VersionManagerInternals, {
+        ipcService: { sendV2 },
+        availableVersionsRefreshPromise: null,
+        installedVersionsRequestPromise: null,
+        installedVersionsRescanQueued: false,
+        installedVersions$: new BehaviorSubject<BSVersion[]>([]),
+        availableVersions$: new BehaviorSubject<BSVersion[]>([]),
+    });
+    return service;
+}
+
+function callsFor(sendV2: jest.Mock, channel: string): unknown[][] {
+    return sendV2.mock.calls.filter(([calledChannel]) => calledChannel === channel);
+}
+
+describe("renderer BSVersionManagerService catalog refresh", () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it("shares one available-version promise, including after the local emission", async () => {
+        const available = new Subject<BSVersion[]>();
+        const sendV2 = jest.fn((channel: string) => {
+            if (channel === "bs-version.get-version-dict") return available.asObservable();
+            throw new Error(`Unexpected IPC channel: ${channel}`);
+        });
+        const service = createService(sendV2);
+        const published: BSVersion[][] = [];
+        const publication = service.availableVersions$.subscribe(versions => published.push(versions));
+
+        const firstCall = service.refreshAvailableVersions();
+        available.next(LOCAL_VERSIONS);
+        const lateCall = service.refreshAvailableVersions();
+
+        expect(lateCall).toBe(firstCall);
+        expect(callsFor(sendV2, "bs-version.get-version-dict")).toEqual([
+            ["bs-version.get-version-dict", { refresh: true }],
+        ]);
+
+        available.next(METADATA_UPDATED_VERSIONS);
+        available.complete();
+
+        await expect(Promise.all([firstCall, lateCall])).resolves.toEqual([
+            METADATA_UPDATED_VERSIONS,
+            METADATA_UPDATED_VERSIONS,
+        ]);
+        expect(published).toEqual([[], LOCAL_VERSIONS, METADATA_UPDATED_VERSIONS]);
+        expect(callsFor(sendV2, "bs-version.installed-versions")).toHaveLength(0);
+
+        publication.unsubscribe();
+    });
+
+    it("does not rescan installed versions for a metadata-only catalog update", async () => {
+        const available = new Subject<BSVersion[]>();
+        const sendV2 = jest.fn((channel: string) => {
+            if (channel === "bs-version.get-version-dict") return available.asObservable();
+            throw new Error(`Unexpected IPC channel: ${channel}`);
+        });
+        const service = createService(sendV2);
+        const refresh = service.refreshAvailableVersions();
+
+        available.next(LOCAL_VERSIONS);
+        available.next(METADATA_UPDATED_VERSIONS);
+        available.complete();
+
+        await expect(refresh).resolves.toBe(METADATA_UPDATED_VERSIONS);
+        expect(callsFor(sendV2, "bs-version.installed-versions")).toHaveLength(0);
+    });
+
+    it("rescans installed versions when the ordered version sequence changes", async () => {
+        const available = new Subject<BSVersion[]>();
+        const sendV2 = jest.fn((channel: string) => {
+            if (channel === "bs-version.get-version-dict") return available.asObservable();
+            if (channel === "bs-version.installed-versions") return of([]);
+            throw new Error(`Unexpected IPC channel: ${channel}`);
+        });
+        const service = createService(sendV2);
+        const refresh = service.refreshAvailableVersions();
+
+        available.next(LOCAL_VERSIONS);
+        available.next(REMOTE_VERSIONS);
+        available.complete();
+
+        await expect(refresh).resolves.toBe(REMOTE_VERSIONS);
+        expect(callsFor(sendV2, "bs-version.installed-versions")).toHaveLength(1);
+    });
+
+    it("does not rescan installed versions after a single catalog emission", async () => {
+        const sendV2 = jest.fn((channel: string) => {
+            if (channel === "bs-version.get-version-dict") return of(LOCAL_VERSIONS);
+            throw new Error(`Unexpected IPC channel: ${channel}`);
+        });
+        const service = createService(sendV2);
+
+        await expect(service.refreshAvailableVersions()).resolves.toBe(LOCAL_VERSIONS);
+        expect(callsFor(sendV2, "bs-version.installed-versions")).toHaveLength(0);
+    });
+
+    it("shares an installed-version promise with a caller arriving after the IPC value", async () => {
+        const installed = new Subject<BSVersion[]>();
+        const sendV2 = jest.fn((channel: string) => {
+            if (channel === "bs-version.installed-versions") return installed.asObservable();
+            throw new Error(`Unexpected IPC channel: ${channel}`);
+        });
+        const service = createService(sendV2);
+        const input = [
+            { BSVersion: "1.39.0", ReleaseDate: "1" },
+            { BSVersion: "1.40.0", ReleaseDate: "2", steam: true },
+            { BSVersion: "1.39.1", ReleaseDate: "3" },
+            { BSVersion: "1.39.1", ReleaseDate: "3" },
+        ] as BSVersion[];
+        const originalOrder = [...input];
+
+        const firstCall = service.askInstalledVersions();
+        installed.next(input);
+        const lateCall = service.askInstalledVersions();
+
+        expect(lateCall).toBe(firstCall);
+        installed.complete();
+
+        const expected = [input[1], input[2], input[0]];
+        await expect(Promise.all([firstCall, lateCall])).resolves.toEqual([expected, expected]);
+        expect(service.installedVersions$.value).toEqual(expected);
+        expect(input).toEqual(originalOrder);
+        expect(callsFor(sendV2, "bs-version.installed-versions")).toHaveLength(1);
+    });
+
+    it("queues one rescan when a catalog update arrives during an installed-version scan", async () => {
+        const available = new Subject<BSVersion[]>();
+        const firstInstalledScan = new Subject<BSVersion[]>();
+        const queuedInstalledScan = new Subject<BSVersion[]>();
+        const installedScans = [firstInstalledScan, queuedInstalledScan];
+        const sendV2 = jest.fn((channel: string) => {
+            if (channel === "bs-version.get-version-dict") return available.asObservable();
+            if (channel === "bs-version.installed-versions") {
+                const scan = installedScans.shift();
+                if (scan) return scan.asObservable();
+            }
+            throw new Error(`Unexpected IPC channel: ${channel}`);
+        });
+        const service = createService(sendV2);
+
+        const activeScan = service.askInstalledVersions();
+        const refresh = service.refreshAvailableVersions();
+
+        available.next(LOCAL_VERSIONS);
+        available.next(REMOTE_VERSIONS);
+        available.complete();
+
+        await expect(refresh).resolves.toBe(REMOTE_VERSIONS);
+        expect(callsFor(sendV2, "bs-version.installed-versions")).toHaveLength(1);
+
+        firstInstalledScan.next([]);
+        firstInstalledScan.complete();
+        await expect(activeScan).resolves.toEqual([]);
+
+        expect(callsFor(sendV2, "bs-version.installed-versions")).toHaveLength(2);
+        const queuedScan = service.askInstalledVersions();
+        queuedInstalledScan.next([]);
+        queuedInstalledScan.complete();
+        await expect(queuedScan).resolves.toEqual([]);
+
+        expect(callsFor(sendV2, "bs-version.installed-versions")).toHaveLength(2);
+    });
+
+    it("runs a queued rescan even when the active installed-version scan fails", async () => {
+        const available = new Subject<BSVersion[]>();
+        const failedInstalledScan = new Subject<BSVersion[]>();
+        const queuedInstalledScan = new Subject<BSVersion[]>();
+        const installedScans = [failedInstalledScan, queuedInstalledScan];
+        const sendV2 = jest.fn((channel: string) => {
+            if (channel === "bs-version.get-version-dict") return available.asObservable();
+            if (channel === "bs-version.installed-versions") {
+                const scan = installedScans.shift();
+                if (scan) return scan.asObservable();
+            }
+            throw new Error(`Unexpected IPC channel: ${channel}`);
+        });
+        const service = createService(sendV2);
+
+        const activeScan = service.askInstalledVersions();
+        const refresh = service.refreshAvailableVersions();
+        available.next(LOCAL_VERSIONS);
+        available.next(REMOTE_VERSIONS);
+        available.complete();
+        await expect(refresh).resolves.toBe(REMOTE_VERSIONS);
+
+        failedInstalledScan.error(new Error("initial scan failed"));
+        await expect(activeScan).rejects.toThrow("initial scan failed");
+        expect(callsFor(sendV2, "bs-version.installed-versions")).toHaveLength(2);
+
+        const queuedScan = service.askInstalledVersions();
+        queuedInstalledScan.next(LOCAL_VERSIONS);
+        queuedInstalledScan.complete();
+
+        await expect(queuedScan).resolves.toEqual(LOCAL_VERSIONS);
+        expect(service.installedVersions$.value).toEqual(LOCAL_VERSIONS);
+    });
+
+    it("clears a failed available-version single-flight so the next call retries", async () => {
+        const failedRefresh = new Subject<BSVersion[]>();
+        const refreshes: Observable<BSVersion[]>[] = [failedRefresh.asObservable(), of(LOCAL_VERSIONS)];
+        const sendV2 = jest.fn((channel: string) => {
+            if (channel === "bs-version.get-version-dict") {
+                const refresh = refreshes.shift();
+                if (refresh) return refresh;
+            }
+            throw new Error(`Unexpected IPC channel: ${channel}`);
+        });
+        const service = createService(sendV2);
+        const firstCall = service.refreshAvailableVersions();
+
+        failedRefresh.error(new Error("IPC failed"));
+        await expect(firstCall).rejects.toThrow("IPC failed");
+        await expect(service.refreshAvailableVersions()).resolves.toBe(LOCAL_VERSIONS);
+
+        expect(callsFor(sendV2, "bs-version.get-version-dict")).toHaveLength(2);
+    });
+
+    it("clears a failed installed-version single-flight so the next call retries", async () => {
+        const failedScan = new Subject<BSVersion[]>();
+        const scans: Observable<BSVersion[]>[] = [failedScan.asObservable(), of(LOCAL_VERSIONS)];
+        const sendV2 = jest.fn((channel: string) => {
+            if (channel === "bs-version.installed-versions") {
+                const scan = scans.shift();
+                if (scan) return scan;
+            }
+            throw new Error(`Unexpected IPC channel: ${channel}`);
+        });
+        const service = createService(sendV2);
+        const firstCall = service.askInstalledVersions();
+
+        failedScan.error(new Error("IPC failed"));
+        await expect(firstCall).rejects.toThrow("IPC failed");
+        await expect(service.askInstalledVersions()).resolves.toEqual(LOCAL_VERSIONS);
+
+        expect(callsFor(sendV2, "bs-version.installed-versions")).toHaveLength(2);
+    });
+});

--- a/src/__tests__/unit/request.service.test.ts
+++ b/src/__tests__/unit/request.service.test.ts
@@ -42,11 +42,11 @@ type MockWriteStream = EventEmitter & {
 
 type RequestServiceInternals = {
     preferredFamilyCache: Record<string, number>;
-    requestData: (url: string, family: number) => Promise<{ data: unknown; headers: Record<string, string> }>;
 };
 
 const netRequestMock = net.request as unknown as jest.Mock;
 const createWriteStreamMock = createWriteStream as unknown as jest.Mock;
+const gotMock = got as unknown as jest.Mock;
 const gotStreamMock = got.stream as unknown as jest.Mock;
 
 function createElectronRequest(): MockElectronRequest {
@@ -93,6 +93,7 @@ describe("RequestService network and memory behavior", () => {
         jest.clearAllMocks();
         netRequestMock.mockReset();
         createWriteStreamMock.mockReset();
+        gotMock.mockReset();
         gotStreamMock.mockReset();
         internals.preferredFamilyCache = {};
     });
@@ -216,30 +217,163 @@ describe("RequestService network and memory behavior", () => {
     });
 
     it("tries IPv4 then IPv6 and caches the first successful family", async () => {
-        const requestData = jest.spyOn(internals, "requestData");
-        requestData
+        gotMock
             .mockRejectedValueOnce(new Error("IPv4 unavailable"))
-            .mockResolvedValueOnce({ data: { ok: true }, headers: {} });
+            .mockResolvedValueOnce({
+                body: '{"ok":true}',
+                headers: { "content-type": "application/json" },
+            });
 
         await expect(service.getJSON("https://example.com/data")).resolves.toEqual({
             data: { ok: true },
-            headers: {},
+            headers: { "content-type": "application/json" },
         });
-        expect(requestData.mock.calls).toEqual([
-            ["https://example.com/data", 4],
-            ["https://example.com/data", 6],
-        ]);
-        expect(internals.preferredFamilyCache["example.com"]).toBe(6);
+
+        expect(gotMock).toHaveBeenCalledTimes(2);
+        expect(gotMock).toHaveBeenNthCalledWith(
+            1,
+            "https://example.com/data",
+            expect.objectContaining({ dnsLookupIpVersion: 4 })
+        );
+        expect(gotMock).toHaveBeenNthCalledWith(
+            2,
+            "https://example.com/data",
+            expect.objectContaining({ dnsLookupIpVersion: 6 })
+        );
+
+        gotMock.mockClear();
+        gotMock.mockResolvedValueOnce({
+            body: '{"cached":true}',
+            headers: { "content-type": "application/json" },
+        });
+
+        await expect(service.getJSON("https://example.com/data")).resolves.toEqual({
+            data: { cached: true },
+            headers: { "content-type": "application/json" },
+        });
+        expect(gotMock).toHaveBeenCalledTimes(1);
+        expect(gotMock).toHaveBeenCalledWith(
+            "https://example.com/data",
+            expect.objectContaining({ dnsLookupIpVersion: 6 })
+        );
+    });
+
+    it("forwards cancellation and retry options to every attempted network family", async () => {
+        const controller = new AbortController();
+        gotMock
+            .mockRejectedValueOnce(new Error("IPv4 unavailable"))
+            .mockResolvedValueOnce({
+                body: '{"ok":true}',
+                headers: { "content-type": "application/json" },
+            });
+
+        await expect(service.getJSON("https://example.com/data", {
+            signal: controller.signal,
+            retryLimit: 0,
+        })).resolves.toEqual({
+            data: { ok: true },
+            headers: { "content-type": "application/json" },
+        });
+
+        expect(gotMock).toHaveBeenCalledTimes(2);
+        expect(gotMock).toHaveBeenNthCalledWith(
+            1,
+            "https://example.com/data",
+            expect.objectContaining({
+                dnsLookupIpVersion: 4,
+                signal: controller.signal,
+                retry: { limit: 0 },
+            })
+        );
+        expect(gotMock).toHaveBeenNthCalledWith(
+            2,
+            "https://example.com/data",
+            expect.objectContaining({
+                dnsLookupIpVersion: 6,
+                signal: controller.signal,
+                retry: { limit: 0 },
+            })
+        );
+    });
+
+    it("keeps cancellation and retry options across a scripted JSON redirect", async () => {
+        const controller = new AbortController();
+        const redirectUrl = "https://example.com/redirected.json";
+        gotMock
+            .mockResolvedValueOnce({
+                body: `document.cookie="session=test";location.href="${redirectUrl}"`,
+                headers: { "content-type": "text/html" },
+            })
+            .mockResolvedValueOnce({
+                body: { ok: true },
+                headers: { "content-type": "application/json" },
+            });
+
+        await expect(service.getJSON("https://example.com/data", {
+            signal: controller.signal,
+            retryLimit: 0,
+        })).resolves.toEqual({
+            data: { ok: true },
+            headers: { "content-type": "application/json" },
+        });
+
+        expect(gotMock).toHaveBeenCalledTimes(2);
+        const firstOptions = gotMock.mock.calls[0][1];
+        const secondOptions = gotMock.mock.calls[1][1];
+        expect(firstOptions).toEqual(expect.objectContaining({
+            signal: controller.signal,
+            retry: { limit: 0 },
+        }));
+        expect(secondOptions).toEqual(expect.objectContaining({
+            signal: controller.signal,
+            retry: { limit: 0 },
+            responseType: "json",
+        }));
+        expect(secondOptions.cookieJar).toBe(firstOptions.cookieJar);
+    });
+
+    it("stops before the next family when the request is aborted", async () => {
+        const controller = new AbortController();
+        const abortError = new Error("catalog request aborted");
+        gotMock.mockImplementationOnce(() => {
+            controller.abort();
+            return Promise.reject(abortError);
+        });
+
+        await expect(service.getJSON("https://example.com/data", {
+            signal: controller.signal,
+            retryLimit: 0,
+        })).rejects.toBe(abortError);
+
+        expect(gotMock).toHaveBeenCalledTimes(1);
+        expect(gotMock).toHaveBeenCalledWith(
+            "https://example.com/data",
+            expect.objectContaining({
+                dnsLookupIpVersion: 4,
+                signal: controller.signal,
+                retry: { limit: 0 },
+            })
+        );
     });
 
     it("does not fall back when a cached family fails", async () => {
-        internals.preferredFamilyCache["example.com"] = 6;
-        const requestData = jest.spyOn(internals, "requestData").mockRejectedValue(new Error("offline"));
+        gotMock
+            .mockRejectedValueOnce(new Error("IPv4 unavailable"))
+            .mockResolvedValueOnce({ body: '{"ok":true}', headers: {} });
+        await service.getJSON("https://example.com/data");
+
+        gotMock.mockClear();
+        const cachedFamilyError = new Error("offline");
+        gotMock.mockRejectedValueOnce(cachedFamilyError);
 
         await expect(service.getJSON("https://example.com/data")).rejects.toThrow(
             "Request failed: https://example.com/data"
         );
-        expect(requestData.mock.calls).toEqual([["https://example.com/data", 6]]);
+        expect(gotMock).toHaveBeenCalledTimes(1);
+        expect(gotMock).toHaveBeenCalledWith(
+            "https://example.com/data",
+            expect.objectContaining({ dnsLookupIpVersion: 6 })
+        );
     });
 
     it("reads the cached family when a download Observable is subscribed", async () => {

--- a/src/main/ipcs/bs-version-ipcs.ts
+++ b/src/main/ipcs/bs-version-ipcs.ts
@@ -10,9 +10,9 @@ import { FolderLinkerService } from "main/services/folder-linker.service";
 
 const ipc = IpcService.getInstance();
 
-ipc.on("bs-version.get-version-dict", (_, reply) => {
+ipc.on("bs-version.get-version-dict", (args, reply) => {
     const versionsLib = BSVersionLibService.getInstance();
-    reply(from(versionsLib.getAvailableVersions()));
+    reply(versionsLib.getAvailableVersions$(args?.refresh));
 });
 
 ipc.on("bs-version.installed-versions", (_, reply) => {

--- a/src/main/services/bs-local-version.service.ts
+++ b/src/main/services/bs-local-version.service.ts
@@ -29,7 +29,7 @@ export class BSLocalVersionService {
     private readonly installLocationService: InstallationLocationService;
     private readonly steamService: SteamService;
     private readonly oculusService: OculusService;
-    private readonly remoteVersionService: BSVersionLibService;
+    private readonly versionLibService: BSVersionLibService;
     private readonly configService: ConfigurationService;
     private readonly linker: FolderLinkerService;
     private readonly staticConfig: StaticConfigurationService;
@@ -46,7 +46,7 @@ export class BSLocalVersionService {
         this.installLocationService = InstallationLocationService.getInstance();
         this.steamService = SteamService.getInstance();
         this.oculusService = OculusService.getInstance();
-        this.remoteVersionService = BSVersionLibService.getInstance();
+        this.versionLibService = BSVersionLibService.getInstance();
         this.configService = ConfigurationService.getInstance();
         this.linker = FolderLinkerService.getInstance();
         this.staticConfig = StaticConfigurationService.getInstance();
@@ -61,7 +61,7 @@ export class BSLocalVersionService {
             return null;
         }
 
-        const versionsDict = (await this.remoteVersionService.getAvailableVersions()).reverse();
+        const versionsDict = [...(await this.versionLibService.getCachedVersions())].reverse();
 
         let stream: ReadStream;
 

--- a/src/main/services/bs-version-lib.service.ts
+++ b/src/main/services/bs-version-lib.service.ts
@@ -1,14 +1,31 @@
 import { UtilsService } from "./utils.service";
 import path from "path";
-import { writeFileSync } from "fs";
+import { writeFile } from "fs/promises";
 import { BSVersion } from "shared/bs-version.interface";
 import { RequestService } from "./request.service";
 import { readJSON } from "fs-extra";
-import { allSettled } from "../../shared/helpers/promise.helpers";
 import { StaticConfigurationService } from "./static-configuration.service";
+import equal from "fast-deep-equal";
+import log from "electron-log";
+import { Observable, concat, defer, filter } from "rxjs";
+
+function isBSVersion(value: unknown): value is BSVersion {
+    return (
+        typeof value === "object"
+        && value !== null
+        && "BSVersion" in value
+        && typeof value.BSVersion === "string"
+        && value.BSVersion.length > 0
+    );
+}
+
+function isBSVersionCatalog(value: unknown): value is BSVersion[] {
+    return Array.isArray(value) && value.every(isBSVersion);
+}
 
 export class BSVersionLibService {
     private readonly REMOTE_BS_VERSIONS_URL: string = "https://raw.githubusercontent.com/Zagrios/bs-manager/master/assets/jsons/bs-versions.json";
+    private readonly REMOTE_BS_VERSIONS_TIMEOUT = 15_000;
     private readonly VERSIONS_FILE: string = "bs-versions.json";
 
     private static instance: BSVersionLibService;
@@ -17,7 +34,9 @@ export class BSVersionLibService {
     private readonly requestService: RequestService;
     private readonly configService: StaticConfigurationService;
 
-    private bsVersions: BSVersion[];
+    private cachedVersions: BSVersion[] | null = null;
+    private loadPromise: Promise<BSVersion[]> | null = null;
+    private refreshPromise: Promise<BSVersion[] | null> | null = null;
 
     private constructor() {
         this.utilsService = UtilsService.getInstance();
@@ -32,60 +51,127 @@ export class BSVersionLibService {
         return BSVersionLibService.instance;
     }
 
-    private async getRemoteVersions(): Promise<BSVersion[]> {
-        return this.requestService.getJSON<BSVersion[]>(this.REMOTE_BS_VERSIONS_URL).then(res => res.data);
+    private async getRemoteVersions(signal: AbortSignal): Promise<unknown> {
+        const response = await this.requestService.getJSON<unknown>(this.REMOTE_BS_VERSIONS_URL, {
+            signal,
+            retryLimit: 0,
+        });
+        return response.data;
     }
 
-    private async getLocalVersions(): Promise<BSVersion[]> {
-        const localVersionsPath = path.join(this.utilsService.getAssestsJsonsPath(), this.VERSIONS_FILE);
+    private getVersionsFilePath(): string {
+        return path.join(this.utilsService.getAssestsJsonsPath(), this.VERSIONS_FILE);
+    }
+
+    private async getLocalVersions(): Promise<unknown> {
+        const localVersionsPath = this.getVersionsFilePath();
 
         if (process.platform !== "linux") {
             return readJSON(localVersionsPath);
         }
 
         let versions = this.configService.get("versions");
-        if (!versions) {
-            versions = await readJSON(localVersionsPath)
+        if (!versions?.length) {
+            versions = await readJSON(localVersionsPath);
         }
         return versions;
     }
 
     private async updateLocalVersions(versions: BSVersion[]): Promise<void> {
         if (process.platform === "linux") {
-            this.configService.set("versions", versions);
+            await this.configService.set("versions", versions);
             return;
         }
 
-        const localVersionsPath = path.join(this.utilsService.getAssestsJsonsPath(), this.VERSIONS_FILE);
-        writeFileSync(localVersionsPath, JSON.stringify(versions, null, "\t"), { encoding: "utf-8", flag: "w" });
+        await writeFile(this.getVersionsFilePath(), JSON.stringify(versions, null, "\t"), { encoding: "utf-8", flag: "w" });
     }
 
-    private async loadBsVersions(): Promise<BSVersion[]> {
-        if (this.bsVersions) {
-            return this.bsVersions;
+    public getCachedVersions(): Promise<BSVersion[]> {
+        if (this.cachedVersions !== null) {
+            return Promise.resolve(this.cachedVersions);
         }
 
-        const [localVersions, remoteVersions] = await allSettled([this.getLocalVersions(), this.getRemoteVersions()], { keepStructure: true });
+        if (this.loadPromise === null) {
+            this.loadPromise = this.getLocalVersions()
+                .then(versions => {
+                    if (!isBSVersionCatalog(versions)) {
+                        log.error("Ignoring an invalid local Beat Saber versions catalog");
+                        this.cachedVersions = [];
+                        return this.cachedVersions;
+                    }
 
-        let resVersions = localVersions;
-        if (remoteVersions?.length) {
-            resVersions = remoteVersions;
-            this.updateLocalVersions(resVersions);
+                    this.cachedVersions = versions;
+                    return this.cachedVersions;
+                })
+                .catch(error => {
+                    log.error("Unable to load the local Beat Saber versions catalog", error);
+                    this.cachedVersions = [];
+                    return this.cachedVersions;
+                })
+                .finally(() => {
+                    this.loadPromise = null;
+                });
         }
-        this.bsVersions = resVersions;
-        return this.bsVersions;
+
+        return this.loadPromise;
     }
 
-    public async getAvailableVersions(): Promise<BSVersion[]> {
-        const bsVersions = await this.loadBsVersions();
-        if (!bsVersions?.length) {
-            return [];
+    private async refreshCachedVersions(): Promise<BSVersion[] | null> {
+        await this.getCachedVersions();
+
+        const abortController = new AbortController();
+        const timeout = setTimeout(() => abortController.abort(), this.REMOTE_BS_VERSIONS_TIMEOUT);
+
+        try {
+            const remoteVersions = await this.getRemoteVersions(abortController.signal);
+            if (!isBSVersionCatalog(remoteVersions) || remoteVersions.length === 0) {
+                log.warn("Ignoring an empty or invalid remote Beat Saber versions catalog");
+                return null;
+            }
+
+            if (equal(this.cachedVersions, remoteVersions)) {
+                return null;
+            }
+
+            this.cachedVersions = remoteVersions;
+            await this.updateLocalVersions(remoteVersions).catch(error => {
+                log.warn("Unable to persist the remote Beat Saber versions catalog", error);
+            });
+
+            return remoteVersions;
+        } catch (error) {
+            log.warn("Unable to refresh the remote Beat Saber versions catalog", error);
+            return null;
+        } finally {
+            clearTimeout(timeout);
         }
-        return bsVersions;
+    }
+
+    private refreshAvailableVersions(): Promise<BSVersion[] | null> {
+        if (this.refreshPromise === null) {
+            this.refreshPromise = this.refreshCachedVersions().finally(() => {
+                this.refreshPromise = null;
+            });
+        }
+
+        return this.refreshPromise;
+    }
+
+    public getAvailableVersions$(refresh = false): Observable<BSVersion[]> {
+        const cachedVersions$ = defer(() => this.getCachedVersions());
+        if (!refresh) {
+            return cachedVersions$;
+        }
+
+        const refreshedVersions$ = defer(() => this.refreshAvailableVersions()).pipe(
+            filter((versions): versions is BSVersion[] => versions !== null)
+        );
+
+        return concat(cachedVersions$, refreshedVersions$);
     }
 
     public async getVersionDetails(version: string): Promise<BSVersion> {
-        const versions = await this.getAvailableVersions();
+        const versions = await this.getCachedVersions();
         return versions.find(v => v.BSVersion === version);
     }
 }

--- a/src/main/services/request.service.ts
+++ b/src/main/services/request.service.ts
@@ -21,6 +21,11 @@ type NetworkFamilySelection = {
     familiesToTry: readonly IpFamily[];
 };
 
+type GetJSONOptions = {
+    signal?: AbortSignal;
+    retryLimit?: number;
+};
+
 type PausableElectronResponse = {
     pause(): void;
     resume(): void;
@@ -161,7 +166,7 @@ export class RequestService {
         });
     }
 
-    public async getJSON<T = unknown>(url: string): Promise<{ data: T; headers: IncomingHttpHeaders }> {
+    public async getJSON<T = unknown>(url: string, options?: GetJSONOptions): Promise<{ data: T; headers: IncomingHttpHeaders }> {
         // Node's HTTP stack has Cloudflare compatibility issues with beatmods.com
         if (this.isBeatmodsUrl(url)) {
             return this.requestWithElectronNet<T>(url);
@@ -171,36 +176,46 @@ export class RequestService {
         const { cachedFamily } = familySelection;
         if (cachedFamily) {
             try {
-                return await this.requestData<T>(url, cachedFamily);
-            } catch (error: any) {
-                throw new Error(`Request failed: ${url}`, error);
+                return await this.requestData<T>(url, cachedFamily, options);
+            } catch (error) {
+                if (options?.signal?.aborted) {
+                    throw error;
+                }
+                throw new Error(`Request failed: ${url}`, { cause: error });
             }
         }
 
         // Try on each IPv4/6 families on first request to a domain/website
         for (const family of familySelection.familiesToTry) {
             try {
-                const response = await this.requestData<T>(url, family);
+                const response = await this.requestData<T>(url, family, options);
                 this.rememberSuccessfulFamily(familySelection, family);
                 return response;
-            } catch (err) {
-                log.warn(`IPv${family} request failed, trying next one... URL: ${url}`, err);
+            } catch (error) {
+                if (options?.signal?.aborted) {
+                    throw error;
+                }
+                log.warn(`IPv${family} request failed, trying next one... URL: ${url}`, error);
             }
         }
 
         throw new Error(`IPv4 and IPv6 requests failed for URL: ${url}`);
     }
 
-    private async requestData<T>(url: string, family: IpFamily): Promise<{ data: T; headers: IncomingHttpHeaders }> {
+    private async requestData<T>(url: string, family: IpFamily, options?: GetJSONOptions): Promise<{ data: T; headers: IncomingHttpHeaders }> {
 
         const cookieJar = new CookieJar();
 
-        const first = await got(url, {
-            // @ts-ignore (ESM is not well supported in this project, We need to move out electron-react-boilerplate, and use Vite)
+        const requestOptions = {
             dnsLookupIpVersion: family,
             cookieJar,
-            headers: this.baseHeaders
-        });
+            headers: this.baseHeaders,
+            ...(options?.signal ? { signal: options.signal } : {}),
+            ...(options?.retryLimit !== undefined ? { retry: { limit: options.retryLimit } } : {}),
+        };
+
+        // @ts-ignore (ESM is not well supported in this project, We need to move out electron-react-boilerplate, and use Vite)
+        const first = await got(url, requestOptions);
 
         // Follow script redirect to get the JSON
         if (first.headers['content-type']?.includes('text/html')) {
@@ -220,12 +235,11 @@ export class RequestService {
             const jsonUrl = redirectMatch[1];
             await cookieJar.setCookie(cookieString, jsonUrl);
 
+            // @ts-ignore (ESM is not well supported in this project, We need to move out electron-react-boilerplate, and use Vite)
             const second = await got(jsonUrl, {
+                ...requestOptions,
                 // @ts-ignore (ESM is not well supported in this project, We need to move out electron-react-boilerplate, and use Vite)
-                dnsLookupIpVersion: family,
                 responseType: "json",
-                cookieJar,
-                headers: this.baseHeaders
             });
 
             return {

--- a/src/renderer/components/nav-bar/nav-bar.component.tsx
+++ b/src/renderer/components/nav-bar/nav-bar.component.tsx
@@ -36,9 +36,7 @@ export function NavBar() {
 
         if (downloadingVersion){ versions.push(downloadingVersion); }
 
-        const sorted = BSVersionManagerService.sortVersions(versions);
-
-        return BSVersionManagerService.removeDuplicateVersions(sorted);
+        return BSVersionManagerService.normalizeInstalledVersions(versions);
     }
 
     return (

--- a/src/renderer/pages/available-versions-list.components.tsx
+++ b/src/renderer/pages/available-versions-list.components.tsx
@@ -83,7 +83,7 @@ export function AvailableVersionsList() {
 
     const refreshVersions = () => {
         return Promise.all([
-            versionManager.askAvailableVersions(),
+            versionManager.refreshAvailableVersions(),
             versionManager.askInstalledVersions()
         ]).catch(logRenderError);
     }

--- a/src/renderer/services/bs-version-manager.service.ts
+++ b/src/renderer/services/bs-version-manager.service.ts
@@ -1,5 +1,5 @@
 import { BSVersion } from "shared/bs-version.interface";
-import { BehaviorSubject, Observable, Subscription, lastValueFrom, map, share, shareReplay, throwError } from "rxjs";
+import { BehaviorSubject, Observable, Subscription, lastValueFrom, shareReplay, tap, throwError } from "rxjs";
 import { IpcService } from "./ipc.service";
 import { ModalExitCode, ModalService } from "./modale.service";
 import { NotificationService } from "./notification.service";
@@ -9,6 +9,7 @@ import { popElement } from "shared/helpers/array.helpers";
 import { ImportVersionModal } from "renderer/components/modal/modal-types/import-version-modal.component";
 import { Progression } from "main/helpers/fs.helpers";
 import { CustomError } from "shared/models/exceptions/custom-error.class";
+import { logRenderError } from "renderer";
 
 export class BSVersionManagerService {
     private static instance: BSVersionManagerService;
@@ -17,9 +18,10 @@ export class BSVersionManagerService {
     private readonly modalService: ModalService;
     private readonly notification: NotificationService;
     private readonly progressBar: ProgressBarService;
-    private readonly modals: ModalService;
 
-    private askInstalledVersionsObserver$: Observable<BSVersion[]> | null = null;
+    private availableVersionsRefreshPromise: Promise<BSVersion[]> | null = null;
+    private installedVersionsRequestPromise: Promise<BSVersion[]> | null = null;
+    private installedVersionsRescanQueued = false;
     public readonly installedVersions$: BehaviorSubject<BSVersion[]> = new BehaviorSubject([]);
     public readonly availableVersions$: BehaviorSubject<BSVersion[]> = new BehaviorSubject([]);
 
@@ -28,10 +30,9 @@ export class BSVersionManagerService {
         this.modalService = ModalService.getInstance();
         this.notification = NotificationService.getInstance();
         this.progressBar = ProgressBarService.getInstance();
-        this.modals = ModalService.getInstance();
 
-        this.askAvailableVersions();
-        this.askInstalledVersions();
+        this.refreshAvailableVersions().catch(logRenderError);
+        this.askInstalledVersions().catch(logRenderError);
     }
 
     public static getInstance() {
@@ -41,52 +42,87 @@ export class BSVersionManagerService {
         return BSVersionManagerService.instance;
     }
 
-    public setInstalledVersions(versions: BSVersion[]) {
-        const sorted = BSVersionManagerService.sortVersions(versions);
-        this.installedVersions$.next(BSVersionManagerService.removeDuplicateVersions(sorted));
+    public setInstalledVersions(versions: BSVersion[]): void {
+        this.installedVersions$.next(BSVersionManagerService.normalizeInstalledVersions(versions));
     }
 
     public getInstalledVersions(): BSVersion[] {
         return this.installedVersions$.value;
     }
 
-    public askAvailableVersions(): Promise<BSVersion[]> {
-        return lastValueFrom(this.ipcService.sendV2("bs-version.get-version-dict")).then(res => {
-            this.availableVersions$.next(res);
-            return res;
-        });
-    }
-
-    public async askInstalledVersions(): Promise<BSVersion[]> {
-        if (this.askInstalledVersionsObserver$) {
-            return lastValueFrom(this.askInstalledVersionsObserver$);
+    public refreshAvailableVersions(): Promise<BSVersion[]> {
+        if (this.availableVersionsRefreshPromise) {
+            return this.availableVersionsRefreshPromise;
         }
 
-        this.askInstalledVersionsObserver$ = this.ipcService
-            .sendV2("bs-version.installed-versions")
-            .pipe(
-                map(versions => {
-                    let processed = BSVersionManagerService.sortVersions(versions);
-                    processed = BSVersionManagerService.removeDuplicateVersions(processed);
-                    return processed;
-                }),
-                share(),
-            );
+        let previousVersions: BSVersion[] | null = null;
 
-        return lastValueFrom(this.askInstalledVersionsObserver$)
+        const refreshPromise = lastValueFrom(
+            this.ipcService.sendV2("bs-version.get-version-dict", { refresh: true }).pipe(
+                tap(versions => {
+                    this.availableVersions$.next(versions);
+
+                    if (
+                        previousVersions
+                        && !BSVersionManagerService.haveSameVersionSequence(previousVersions, versions)
+                    ) {
+                        this.queueInstalledVersionsRescan();
+                    }
+
+                    previousVersions = versions;
+                }),
+            )
+        ).finally(() => {
+            if (this.availableVersionsRefreshPromise === refreshPromise) {
+                this.availableVersionsRefreshPromise = null;
+            }
+        });
+
+        this.availableVersionsRefreshPromise = refreshPromise;
+        return refreshPromise;
+    }
+
+    private queueInstalledVersionsRescan(): void {
+        if (this.installedVersionsRequestPromise) {
+            this.installedVersionsRescanQueued = true;
+            return;
+        }
+
+        this.askInstalledVersions().catch(logRenderError);
+    }
+
+    public askInstalledVersions(): Promise<BSVersion[]> {
+        if (this.installedVersionsRequestPromise) {
+            return this.installedVersionsRequestPromise;
+        }
+
+        const requestPromise = lastValueFrom(this.ipcService.sendV2("bs-version.installed-versions"))
             .then(versions => {
-                this.setInstalledVersions(versions);
-                return versions;
+                const normalizedVersions = BSVersionManagerService.normalizeInstalledVersions(versions);
+                this.installedVersions$.next(normalizedVersions);
+                return normalizedVersions;
             })
             .finally(() => {
-                this.askInstalledVersionsObserver$ = null;
+                if (this.installedVersionsRequestPromise !== requestPromise) {
+                    return;
+                }
+
+                this.installedVersionsRequestPromise = null;
+
+                if (this.installedVersionsRescanQueued) {
+                    this.installedVersionsRescanQueued = false;
+                    this.askInstalledVersions().catch(logRenderError);
+                }
             });
+
+        this.installedVersionsRequestPromise = requestPromise;
+        return requestPromise;
     }
 
     public async isVersionInstalled(version: BSVersion): Promise<boolean> {
         try {
-            const versions: BSVersion[] = this.askInstalledVersionsObserver$
-                ? await lastValueFrom(this.askInstalledVersionsObserver$)
+            const versions: BSVersion[] = this.installedVersionsRequestPromise
+                ? await this.installedVersionsRequestPromise
                 : this.getInstalledVersions();
 
             return !!versions.find(v =>
@@ -110,7 +146,7 @@ export class BSVersionManagerService {
         }
 
         return lastValueFrom(this.ipcService.sendV2("bs-version.edit", { version, name: modalRes.data.name, color: modalRes.data.color })).then(res => {
-            this.askInstalledVersions();
+            this.askInstalledVersions().catch(logRenderError);
             return res;
         }).catch(e => {
 
@@ -146,7 +182,7 @@ export class BSVersionManagerService {
 
         return lastValueFrom(this.ipcService.sendV2("bs-version.clone", { version, name: modalRes.data.name, color: modalRes.data.color })).then(res => {
             this.notification.notifySuccess({ title: "notifications.custom-version.success.titles.CloningFinished" });
-            this.askInstalledVersions();
+            this.askInstalledVersions().catch(logRenderError);
             return res;
         }).catch((e: CustomError) => {
 
@@ -175,7 +211,7 @@ export class BSVersionManagerService {
 
             (async () => {
 
-                const resModal = await this.modals.openModal(ImportVersionModal);
+                const resModal = await this.modalService.openModal(ImportVersionModal);
                 if(resModal.exitCode !== ModalExitCode.COMPLETED){
                     return;
                 }
@@ -201,7 +237,7 @@ export class BSVersionManagerService {
                 this.notification.notifyError({ title: "notifications.types.error", desc: "notifications.bs-import-version.errors.import-error.desc" });
                 obs.error(err)
             }).finally(() => {
-                this.askInstalledVersions();
+                this.askInstalledVersions().catch(logRenderError);
                 this.progressBar.hide();
             });
 
@@ -222,16 +258,28 @@ export class BSVersionManagerService {
     }
 
     public static sortVersions(versions: BSVersion[]): BSVersion[] {
-        const steamVersion = popElement(v => v.steam, versions);
-        const oculusVersion = popElement(v => v.oculus, versions);
+        const sorted = [...versions];
+        const steamVersion = popElement(v => v.steam, sorted);
+        const oculusVersion = popElement(v => v.oculus, sorted);
 
-        const compare = (a: BSVersion, b: BSVersion) => ( +b.ReleaseDate - +a.ReleaseDate )
+        const compare = (a: BSVersion, b: BSVersion) => ( +b.ReleaseDate - +a.ReleaseDate );
 
-        const sorted: BSVersion[] = versions.sort(compare);
+        sorted.sort(compare);
 
         sorted.unshift(...[steamVersion, oculusVersion].filter(Boolean).sort(compare));
 
         return sorted;
+    }
+
+    public static normalizeInstalledVersions(versions: BSVersion[]): BSVersion[] {
+        return BSVersionManagerService.removeDuplicateVersions(
+            BSVersionManagerService.sortVersions(versions)
+        );
+    }
+
+    private static haveSameVersionSequence(first: BSVersion[], second: BSVersion[]): boolean {
+        return first.length === second.length
+            && first.every((version, index) => version.BSVersion === second[index].BSVersion);
     }
 
     public static removeDuplicateVersions(versions: BSVersion[]): BSVersion[] {

--- a/src/renderer/services/bs-version-manager.service.ts
+++ b/src/renderer/services/bs-version-manager.service.ts
@@ -51,7 +51,7 @@ export class BSVersionManagerService {
     }
 
     public refreshAvailableVersions(): Promise<BSVersion[]> {
-        if (this.availableVersionsRefreshPromise) {
+        if (this.availableVersionsRefreshPromise !== null) {
             return this.availableVersionsRefreshPromise;
         }
 
@@ -83,7 +83,7 @@ export class BSVersionManagerService {
     }
 
     private queueInstalledVersionsRescan(): void {
-        if (this.installedVersionsRequestPromise) {
+        if (this.installedVersionsRequestPromise !== null) {
             this.installedVersionsRescanQueued = true;
             return;
         }
@@ -92,7 +92,7 @@ export class BSVersionManagerService {
     }
 
     public askInstalledVersions(): Promise<BSVersion[]> {
-        if (this.installedVersionsRequestPromise) {
+        if (this.installedVersionsRequestPromise !== null) {
             return this.installedVersionsRequestPromise;
         }
 
@@ -121,7 +121,7 @@ export class BSVersionManagerService {
 
     public async isVersionInstalled(version: BSVersion): Promise<boolean> {
         try {
-            const versions: BSVersion[] = this.installedVersionsRequestPromise
+            const versions: BSVersion[] = this.installedVersionsRequestPromise !== null
                 ? await this.installedVersionsRequestPromise
                 : this.getInstalledVersions();
 

--- a/src/shared/models/ipc/ipc-routes.ts
+++ b/src/shared/models/ipc/ipc-routes.ts
@@ -108,7 +108,7 @@ export interface IpcChannelMapping {
     "bs.uninstall": { request: BSVersion, response: void };
 
     /* ** bs-version-ipcs ** */
-    "bs-version.get-version-dict": { request: void, response: BSVersion[] };
+    "bs-version.get-version-dict": { request: { refresh?: boolean }, response: BSVersion[] };
     "bs-version.installed-versions": { request: void, response: BSVersion[] };
     "bs-version.open-folder": { request: BSVersion, response: void };
     "bs-version.edit": { request: { version: BSVersion; name: string; color: string }, response: BSVersion };


### PR DESCRIPTION
Load cached Beat Saber versions immediately and refresh them in the background, keeping installed versions available without Internet access.

Closes #1096
